### PR TITLE
feat(config): add configurable Hangfire options, add ValidateDataAnnotations

### DIFF
--- a/src/DotNetAtlas.Api/Common/ApiDependencyInjection.cs
+++ b/src/DotNetAtlas.Api/Common/ApiDependencyInjection.cs
@@ -77,7 +77,9 @@ public static class ApiDependencyInjection
         ConfigurationManager configuration)
     {
         services.AddOptionsWithValidateOnStart<CorsPolicyOptions>()
-            .Bind(configuration.GetSection(CorsPolicyOptions.Section));
+            .Bind(configuration.GetSection(CorsPolicyOptions.Section))
+            .ValidateDataAnnotations();
+
         var corsOptions =
             configuration.GetRequiredSection(CorsPolicyOptions.Section).Get<CorsPolicyOptions>()!;
 

--- a/src/DotNetAtlas.Api/appsettings.json
+++ b/src/DotNetAtlas.Api/appsettings.json
@@ -134,9 +134,20 @@
     "CircuitBreakerFailureRatio": 0.2,
     "CircuitBreakerBreakSeconds": 5
   },
+  "Hangfire": {
+    "JobExpirationCheckIntervalMs": 600000,
+    "QueuePollIntervalMs": 3000,
+    "SchedulePollingIntervalMs": 10000,
+    "CancellationCheckIntervalMs": 5000,
+    "Queues": [
+      "weatheralert",
+      "default"
+    ]
+  },
   "Jobs": {
     "FakeWeatherAlert": {
-      "Cron": "*/10 * * * * *"
+      "Cron": "*/10 * * * * *",
+      "Queue": "weatheralert"
     }
   },
   "Kafka": {

--- a/src/DotNetAtlas.Application/Common/ApplicationDependencyInjection.cs
+++ b/src/DotNetAtlas.Application/Common/ApplicationDependencyInjection.cs
@@ -35,9 +35,11 @@ public static class ApplicationDependencyInjection
     private static IServiceCollection AddForecast(this IServiceCollection services, ConfigurationManager configuration)
     {
         services.AddOptionsWithValidateOnStart<WeatherHedgingOptions>()
-            .Bind(configuration.GetSection(WeatherHedgingOptions.Section));
+            .Bind(configuration.GetSection(WeatherHedgingOptions.Section))
+            .ValidateDataAnnotations();
         services.AddOptionsWithValidateOnStart<ForecastCacheOptions>()
-            .Bind(configuration.GetSection(ForecastCacheOptions.Section));
+            .Bind(configuration.GetSection(ForecastCacheOptions.Section))
+            .ValidateDataAnnotations();
 
         services.AddScoped<IWeatherForecastService, HedgingWeatherForecastService>();
         services.Decorate<IWeatherForecastService, CachedWeatherForecastService>();

--- a/src/DotNetAtlas.Application/Forecast/Common/Config/WeatherHedgingOptions.cs
+++ b/src/DotNetAtlas.Application/Forecast/Common/Config/WeatherHedgingOptions.cs
@@ -6,6 +6,6 @@ public sealed class WeatherHedgingOptions
 {
     public const string Section = "Weather:Hedging";
 
-    [Range(1, 1_000)]
+    [Range(1, 10_000)]
     public int PrimaryMaxDurationMs { get; set; }
 }

--- a/src/DotNetAtlas.Application/Forecast/Services/CachedWeatherForecastService.cs
+++ b/src/DotNetAtlas.Application/Forecast/Services/CachedWeatherForecastService.cs
@@ -4,6 +4,7 @@ using DotNetAtlas.Application.Forecast.Services.Abstractions;
 using DotNetAtlas.Application.Forecast.Services.Requests;
 using FluentResults;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace DotNetAtlas.Application.Forecast.Services;
@@ -19,7 +20,7 @@ public class CachedWeatherForecastService : IWeatherForecastService
         IWeatherForecastService decoratedForecastService,
         IFusionCache fusionCache,
         ILogger<CachedWeatherForecastService> logger,
-        Microsoft.Extensions.Options.IOptions<ForecastCacheOptions> options)
+        IOptions<ForecastCacheOptions> options)
     {
         _decoratedForecastService = decoratedForecastService;
         _fusionCache = fusionCache;

--- a/src/DotNetAtlas.Infrastructure/Jobs/FakeWeatherAlertJob.cs
+++ b/src/DotNetAtlas.Infrastructure/Jobs/FakeWeatherAlertJob.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace DotNetAtlas.Infrastructure.Jobs;
 
-[AutomaticRetry(Attempts = 3, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
+[AutomaticRetry(Attempts = 3, OnAttemptsExceeded = AttemptsExceededAction.Fail, LogEvents = true)]
 internal sealed class FakeWeatherAlertJob : IJob
 {
     private static readonly string[] AlertMessages =

--- a/src/DotNetAtlas.Infrastructure/Jobs/FakeWeatherAlertJobOptions.cs
+++ b/src/DotNetAtlas.Infrastructure/Jobs/FakeWeatherAlertJobOptions.cs
@@ -7,5 +7,8 @@ public sealed class FakeWeatherAlertJobOptions
     public const string Section = "Jobs:FakeWeatherAlert";
 
     [Required(AllowEmptyStrings = false)]
-    public string Cron { get; set; } = "*/10 * * * * *"; // default every 10 seconds
+    public required string Cron { get; set; }
+
+    [Required(AllowEmptyStrings = false)]
+    public required string Queue { get; set; }
 }

--- a/src/DotNetAtlas.Infrastructure/Jobs/HangfireOptions.cs
+++ b/src/DotNetAtlas.Infrastructure/Jobs/HangfireOptions.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.Infrastructure.Jobs;
+
+public sealed class HangfireOptions
+{
+    public const string Section = "Hangfire";
+
+    [Required]
+    [Range(1, int.MaxValue)]
+    public required int JobExpirationCheckIntervalMs { get; set; }
+
+    [Required]
+    [Range(1, int.MaxValue)]
+    public required int QueuePollIntervalMs { get; set; }
+
+    [Required]
+    [Range(1, int.MaxValue)]
+    public required int SchedulePollingIntervalMs { get; set; }
+
+    [Required]
+    [Range(1, int.MaxValue)]
+    public required int CancellationCheckIntervalMs { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    public required string[] Queues { get; set; }
+}

--- a/src/DotNetAtlas.Infrastructure/Jobs/HangfireWeatherAlertJobScheduler.cs
+++ b/src/DotNetAtlas.Infrastructure/Jobs/HangfireWeatherAlertJobScheduler.cs
@@ -30,8 +30,11 @@ internal sealed class HangfireWeatherAlertJobScheduler : IWeatherAlertJobSchedul
             methodCall: job =>
                 job.SendWeatherAlert(alertSubscriptionDto,
                     CancellationToken.None), // hangfire resolves cancellation token on its own
-            cronExpression: _fakeWeatherAlertJobOptions.Cron);
-        _logger.LogInformation("Scheduled alerts for {Group}", groupName);
+            cronExpression: _fakeWeatherAlertJobOptions.Cron,
+            queue: _fakeWeatherAlertJobOptions.Queue);
+
+        _logger.LogInformation(
+            "Scheduled alerts for {Group} on queue {Queue}", groupName, _fakeWeatherAlertJobOptions.Queue);
     }
 
     public void TriggerAlertJobForGroup(AlertSubscriptionDto alertSubscriptionDto, string groupName)


### PR DESCRIPTION
### **User description**

Introduce HangfireOptions class to make Hangfire polling intervals and queue configuration externally configurable. Add ValidateDataAnnotations() to all options configurations across API, Application, and Infrastructure layers for runtime validation. Update job scheduling to support custom queues for better workload management.

- Create HangfireOptions with configurable JobExpirationCheckInterval, QueuePollInterval, SchedulePollingInterval, CancellationCheckInterval, and Queues
- Add Queue property to FakeWeatherAlertJobOptions for queue-specific job scheduling
- Enable data annotation validation on all IOptions configurations
- Change FakeWeatherAlertJob retry behavior from Delete to Fail on attempts exceeded
- Increase WeatherHedgingOptions PrimaryMaxDurationMs range from 1,000 to 10,000

BREAKING CHANGE: FakeWeatherAlertJobOptions now requires Queue property and HangfireOptions section must be configured in appsettings.json

---

### **PR Type**

Enhancement

---

### **Description**

- Add HangfireOptions configuration class for externally configurable polling intervals and queues
- Enable ValidateDataAnnotations() on all IOptions configurations across API, Application, and Infrastructure layers
- Make FakeWeatherAlertJobOptions.Queue required property for queue-specific job scheduling
- Change FakeWeatherAlertJob retry behavior from Delete to Fail on attempts exceeded
- Increase WeatherHedgingOptions.PrimaryMaxDurationMs range from 1,000 to 10,000 milliseconds

---

### Diagram Walkthrough

```mermaid
flowchart LR
  HangfireOpts["HangfireOptions<br/>polling intervals & queues"]
  ValidateDA["ValidateDataAnnotations<br/>on all IOptions"]
  JobConfig["FakeWeatherAlertJobOptions<br/>requires Queue property"]
  RetryBehavior["FakeWeatherAlertJob<br/>Delete → Fail"]
  DurationRange["WeatherHedgingOptions<br/>1K → 10K ms"]
  
  HangfireOpts --> JobConfig
  ValidateDA --> HangfireOpts
  ValidateDA --> JobConfig
  JobConfig --> RetryBehavior
  ValidateDA --> DurationRange
```

<details>
<summary></summary>
<table>
<tr>
<th></th>
<th align="left">Relevant files</th>
</tr>
<tr>
<td>

**HangfireOptions.cs**

<dd><code>New HangfireOptions configuration class</code>                                    </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-e757c8d4ab8b92c9dd8d44421db6a682338099f80976e0a74a5525c2fca54c03">\+24/-0</a>

</td>
</tr>
<tr>
<td>

**FakeWeatherAlertJobOptions.cs**

<dd><code>Add required Queue property to job options</code>                              </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-f0e88e4ffa3c2e94f9f9e9aa69cfd6f614d0d1451ef284496d3c3e8b72759eaf">\+4/-1</a>

</td>
</tr>
<tr>
<td>

**FakeWeatherAlertJob.cs**

<dd><code>Change retry behavior from Delete to Fail</code>                                </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-e06678b555f3ee965e4bdf0112e37b6520c5784055bfbed00b98c1c9ee550759">\+1/-1</a>

</td>
</tr>
<tr>
<td>

**HangfireWeatherAlertJobScheduler.cs**

<dd><code>Use queue from options in job scheduling</code>                                  </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-980a376b9ede714b40e722eee9f94be6861bd98903f5296cbf7d1b06047a917d">\+5/-2</a>

</td>
</tr>
<tr>
<td>

**InfrastructureDependencyInjection.cs**

<dd><code>Add HangfireOptions configuration and ValidateDataAnnotations</code></dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-e5c1b971879e8492adb4c05da688aee3927b3f5ea55fbc5d76b92719d2e4536d">\+36/-10</a>

</td>
</tr>
<tr>
<td>

**ApplicationDependencyInjection.cs**

<dd><code>Enable ValidateDataAnnotations on forecast options</code>              </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-e66118557d4998acbfaed2dd6ee698e404d019b71dc2eeba00b945d522edaa0c">\+4/-2</a>

</td>
</tr>
<tr>
<td>

**ApiDependencyInjection.cs**

<dd><code>Enable ValidateDataAnnotations on CORS options</code>                      </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-23b31e6cdb305391cfeace9a4d69245cf1c6742b3e760e227197af3b3ced55c4">\+3/-1</a>

</td>
</tr>
<tr>
<td>

**WeatherHedgingOptions.cs**

<dd><code>Increase PrimaryMaxDurationMs range to 10,000</code>                        </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-280fe151842f1e0dae65f2db3b1486739535e0ebdafb20bcc5d544ab0e2ce3b4">\+1/-1</a>

</td>
</tr>
</table>

**Formatting**

<details>
<summary>1 files</summary>
<table>
<tr>
<td>

**CachedWeatherForecastService.cs**

<dd><code>Simplify IOptions import and add using statement</code>                  </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-4d8ee36811926081bab7025a42da0b8c2441180faa18f1dce185f98cf9e92b92">\+2/-1</a>

</td>
</tr>
</table>
</details>

**Configuration changes**

<details>
<summary>1 files</summary>
<table>
<tr>
<td>

**appsettings.json**

<dd><code>Add Hangfire configuration and Queue to job settings</code>          </dd>

</td>
<td>

<a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/37/files#diff-a80d204f29493ae029bf3312e35841b7fb88973b0804279c53bbffda489fca12">\+12/-1</a>

</td>
</tr>
</table>
</details>

</details>

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `HangfireOptions` for configurable intervals/queues, enforces `ValidateDataAnnotations()` on options, schedules weather alert jobs to a configured queue, updates retry behavior, and expands hedging duration range.
> 
> - **Jobs / Hangfire**:
>   - Introduce `HangfireOptions` (polling intervals, queues) with data annotation validation and wire into Hangfire storage/server (`SqlServerStorageOptions`, server intervals, `options.Queues`).
>   - Schedule `FakeWeatherAlertJob` on a configurable queue via `HangfireWeatherAlertJobScheduler` and log the queue.
>   - Change `FakeWeatherAlertJob` retry behavior to `AttemptsExceededAction.Fail` with `LogEvents = true`.
> - **Configuration**:
>   - Update `appsettings.json` with `Hangfire` section and add `Queue` under `Jobs:FakeWeatherAlert`.
>   - Make `FakeWeatherAlertJobOptions` require `Cron` and new required `Queue`.
> - **Validation**:
>   - Apply `.ValidateDataAnnotations()` to option bindings across API/Application/Infrastructure (`CorsPolicyOptions`, `WeatherHedgingOptions`, `ForecastCacheOptions`, `ApplicationOptions`, `OpenMeteoOptions`, `WeatherApiComOptions`, `HttpResilienceOptions`, `DefaultCacheOptions`, `FakeWeatherAlertJobOptions`).
> - **Other**:
>   - Increase `WeatherHedgingOptions.PrimaryMaxDurationMs` range to `1..10_000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 414c0a807d36e8ff6ca83a7f9c5b472e0ce883f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->