### PR TITLE
feat(efcore): Use DbContextPooling for perf, add efcoreoptions, detailed errors, sensitive data logging

### DIFF
--- a/src/DotNetAtlas.Api/appsettings.json
+++ b/src/DotNetAtlas.Api/appsettings.json
@@ -111,6 +111,13 @@
       "EagerRefreshThreshold": 0.9
     }
   },
+  "EfCore": {
+    "DbContextPoolSize": 256,
+    "UseQuerySplitting": true,
+    "RetryMaxCount": 6,
+    "RetryMaxDelaySeconds": 30,
+    "EnableDetailedErrors": true
+  },
   "DefaultCache": {
     "DistributedCacheCircuitBreakerSeconds": 2,
     "IncludeTagsInLogs": true,

--- a/src/DotNetAtlas.Infrastructure/Common/Config/EfCoreOptions.cs
+++ b/src/DotNetAtlas.Infrastructure/Common/Config/EfCoreOptions.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.Infrastructure.Common.Config;
+
+public sealed class EfCoreOptions
+{
+    public const string Section = "EfCore";
+
+    [Required]
+    [Range(1, 4096)]
+    public required int DbContextPoolSize { get; set; }
+
+    [Required]
+    public required bool UseQuerySplitting { get; set; }
+
+    [Required]
+    [Range(0, 10)]
+    public required int RetryMaxCount { get; set; }
+
+    [Required]
+    [Range(1, 180)]
+    public required int RetryMaxDelaySeconds { get; set; }
+
+    [Required]
+    public required bool EnableDetailedErrors { get; set; }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implement DbContext pooling for improved performance

- Add configurable EfCoreOptions for database settings

- Enable sensitive data logging and detailed error reporting

- Make retry policy and query splitting behavior configurable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EfCoreOptions Config"] -->|"DbContextPoolSize, Retry, QuerySplitting"| B["AddDatabase Method"]
  B -->|"AddDbContextPool"| C["WeatherForecastContext"]
  B -->|"EnableSensitiveDataLogging"| C
  B -->|"EnableDetailedErrors"| C
  D["appsettings.json"] -->|"Provides values"| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EfCoreOptions.cs</strong><dd><code>Create EfCoreOptions configuration class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Infrastructure/Common/Config/EfCoreOptions.cs

<ul><li>New configuration class for Entity Framework Core settings<br> <li> Includes DbContextPoolSize, UseQuerySplitting, RetryMaxCount, <br>RetryMaxDelaySeconds, and EnableDetailedErrors properties<br> <li> All properties are required with data annotations for validation</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/44/files#diff-8f2c6d9f3292cb1f56498141ce685e71d4bafb6b3c60a5efa8d2178109803ea7">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appsettings.json</strong><dd><code>Add EfCore configuration settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Api/appsettings.json

<ul><li>Add new EfCore configuration section with pooling and retry settings<br> <li> Set DbContextPoolSize to 256 for performance optimization<br> <li> Configure query splitting, retry behavior, and error reporting options</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/44/files#diff-a80d204f29493ae029bf3312e35841b7fb88973b0804279c53bbffda489fca12">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InfrastructureDependencyInjection.cs</strong><dd><code>Implement DbContext pooling and configurable options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Infrastructure/Common/InfrastructureDependencyInjection.cs

<ul><li>Replace AddDbContext with AddDbContextPool for connection pooling<br> <li> Register EfCoreOptions with validation on startup<br> <li> Make UpdateAuditableEntitiesInterceptor a singleton instead of scoped<br> <li> Use configurable values for retry policy, query splitting, and error <br>reporting<br> <li> Add isClusterEnvironment parameter to control sensitive data logging</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/44/files#diff-e5c1b971879e8492adb4c05da688aee3927b3f5ea55fbc5d76b92719d2e4536d">+25/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches to DbContext pooling and makes EF Core retry, query splitting, and error detail settings configurable via new EfCore options.
> 
> - **Database/Infrastructure**:
>   - Replace `AddDbContext` with `AddDbContextPool<WeatherForecastContext>` using configurable `poolSize`.
>   - Configure `UseQuerySplittingBehavior`, `EnableRetryOnFailure`, and `EnableDetailedErrors` from `EfCoreOptions`.
>   - Enable `EnableSensitiveDataLogging` only when not in cluster (`isClusterEnvironment`).
>   - Change `UpdateAuditableEntitiesInterceptor` registration to singleton and add via interceptors.
>   - Update `AddDatabase` to accept `isClusterEnvironment`; call site adjusted.
> - **Configuration**:
>   - Add `EfCore` section in `appsettings.json` (`DbContextPoolSize`, `UseQuerySplitting`, `RetryMaxCount`, `RetryMaxDelaySeconds`, `EnableDetailedErrors`).
>   - Introduce `EfCoreOptions` class with data annotations and startup validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5dca1b77fb504e74ae30c780a7ae79cf9db3b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->