### PR TITLE
ci(test): add Docker Image caching for TestContainers

### DIFF
--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-with-coverage:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -29,6 +29,11 @@ jobs:
         env:
           CONFIGURATION: ${{ inputs.configuration }}
         run: dotnet build -c "$CONFIGURATION" --no-restore
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.5.0
+        continue-on-error: true
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('test/DotNetAtlas.Test.Framework/**/*Container.cs') }}
       - name: Test with coverage
         env:
           CONFIGURATION: ${{ inputs.configuration }}

--- a/test/DotNetAtlas.ArchitectureTests/Application/ApplicationTests.cs
+++ b/test/DotNetAtlas.ArchitectureTests/Application/ApplicationTests.cs
@@ -16,7 +16,7 @@ public class ApplicationTests : BaseTest
             .HaveNameEndingWith("Validator")
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class ApplicationTests : BaseTest
             .HaveNameEndingWith("Handler")
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class ApplicationTests : BaseTest
             .HaveNameEndingWith("Command")
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -58,6 +58,6 @@ public class ApplicationTests : BaseTest
             .HaveNameEndingWith("Query")
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 }

--- a/test/DotNetAtlas.ArchitectureTests/BaseTest.cs
+++ b/test/DotNetAtlas.ArchitectureTests/BaseTest.cs
@@ -3,6 +3,7 @@ using DotNetAtlas.Api.Common;
 using DotNetAtlas.Application.Common;
 using DotNetAtlas.Domain.Common;
 using DotNetAtlas.Infrastructure.Common;
+using DotNetAtlas.Test.Framework.Kafka;
 
 namespace DotNetAtlas.ArchitectureTests;
 
@@ -12,4 +13,6 @@ public abstract class BaseTest
     protected static readonly Assembly ApplicationAssembly = typeof(ApplicationDependencyInjection).Assembly;
     protected static readonly Assembly InfrastructureAssembly = typeof(InfrastructureDependencyInjection).Assembly;
     protected static readonly Assembly PresentationAssembly = typeof(ApiDependencyInjection).Assembly;
+
+    protected static readonly Assembly TestFrameworkAssembly = typeof(KafkaTestContainer).Assembly;
 }

--- a/test/DotNetAtlas.ArchitectureTests/CleanArchitecture/CleanArchitectureLayerTests.cs
+++ b/test/DotNetAtlas.ArchitectureTests/CleanArchitecture/CleanArchitectureLayerTests.cs
@@ -11,7 +11,8 @@ public class CleanArchitectureLayerTests : BaseTest
             .Should()
             .NotHaveDependencyOnAny(ApplicationAssembly.GetName().Name)
             .GetResult();
-        result.IsSuccessful.Should().BeTrue();
+
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -22,7 +23,7 @@ public class CleanArchitectureLayerTests : BaseTest
             .NotHaveDependencyOnAny(InfrastructureAssembly.GetName().Name)
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class CleanArchitectureLayerTests : BaseTest
             .NotHaveDependencyOnAny(PresentationAssembly.GetName().Name)
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -44,7 +45,7 @@ public class CleanArchitectureLayerTests : BaseTest
             .NotHaveDependencyOnAny(InfrastructureAssembly.GetName().Name)
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public class CleanArchitectureLayerTests : BaseTest
             .NotHaveDependencyOnAny(PresentationAssembly.GetName().Name)
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 
     [Fact]
@@ -66,6 +67,6 @@ public class CleanArchitectureLayerTests : BaseTest
             .NotHaveDependencyOnAny(PresentationAssembly.GetName().Name)
             .GetResult();
 
-        result.IsSuccessful.Should().BeTrue();
+        result.FailingTypes.Should().BeEmpty();
     }
 }

--- a/test/DotNetAtlas.ArchitectureTests/TestFramework/TestContainersNamingTests.cs
+++ b/test/DotNetAtlas.ArchitectureTests/TestFramework/TestContainersNamingTests.cs
@@ -1,0 +1,24 @@
+using DotNetAtlas.Test.Framework.Common;
+using NetArchTest.Rules;
+
+namespace DotNetAtlas.ArchitectureTests.TestFramework;
+
+public class TestContainersNamingTests : BaseTest
+{
+    /// <summary>
+    /// In the CI pipeline, docker images used by the TestContainers are cached and cache keys are created
+    /// using the hash of *Container.cs files in the TestFrameworkAssembly.
+    /// </summary>
+    [Fact]
+    public void All_TestContainers_With_ImageName_Property_End_With_Container()
+    {
+        var result = Types.InAssembly(TestFrameworkAssembly)
+            .That()
+            .ImplementInterface<ITestContainer>()
+            .Should()
+            .HaveNameEndingWith("Container")
+            .GetResult();
+
+        result.FailingTypes.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
### **User description**
Add Docker image caching using ScribeMD/docker-cache to speed up test
execution. Cache key is based on TestContainer file hashes to ensure
proper invalidation when container definitions change. Architecture test ensures files are found

- Add docker-cache step to test-with-coverage workflow
- Add architecture test enforcing Container naming for cache key generation
- Refactor test assertions to use FailingTypes, if this assertion fails, you immeditealy know what's wrong in the error message


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactor architecture test assertions to use `FailingTypes` for clearer error messages

- Add Docker image caching for TestContainers in CI pipeline

- Introduce `TestContainersNamingTests` to enforce Container naming convention

- Add `TestFrameworkAssembly` reference and reduce workflow timeout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Architecture Tests"] -->|"Refactor assertions"| B["Use FailingTypes"]
  C["CI Workflow"] -->|"Add caching step"| D["Docker Image Cache"]
  D -->|"Cache key based on"| E["*Container.cs files"]
  F["New Test Class"] -->|"Validates naming"| G["ITestContainer implementations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApplicationTests.cs</strong><dd><code>Refactor assertions to use FailingTypes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/DotNetAtlas.ArchitectureTests/Application/ApplicationTests.cs

<ul><li>Replace <code>result.IsSuccessful.Should().BeTrue()</code> with <br><code>result.FailingTypes.Should().BeEmpty()</code> in 4 test methods<br> <li> Improves error messages by showing actual failing types when <br>assertions fail</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/48/files#diff-0134b1d3e6eb32b3150901f0d7a0febc841c9dddd015999e14066333674fdb7f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BaseTest.cs</strong><dd><code>Add TestFrameworkAssembly reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/DotNetAtlas.ArchitectureTests/BaseTest.cs

<ul><li>Add import for <code>DotNetAtlas.Test.Framework.Kafka</code><br> <li> Add <code>TestFrameworkAssembly</code> static field referencing <code>KafkaTestContainer</code><br> <li> Enables architecture tests to validate TestFramework assembly types</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/48/files#diff-46678f6c3835b56c8c0f5ebc040555ed58e473fb59bb700e53ae4c66c14f1c59">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CleanArchitectureLayerTests.cs</strong><dd><code>Refactor layer dependency assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/DotNetAtlas.ArchitectureTests/CleanArchitecture/CleanArchitectureLayerTests.cs

<ul><li>Replace <code>result.IsSuccessful.Should().BeTrue()</code> with <br><code>result.FailingTypes.Should().BeEmpty()</code> in 7 test methods<br> <li> Provides more descriptive failure messages showing which types violate <br>layer dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/48/files#diff-e2e1b515ff36cdc12f2a9c2a201d6bd9931758927d196a1b6a67c663f61bcc91">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestContainersNamingTests.cs</strong><dd><code>Add TestContainers naming convention test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/DotNetAtlas.ArchitectureTests/TestFramework/TestContainersNamingTests.cs

<ul><li>New test class enforcing naming convention for TestContainer <br>implementations<br> <li> Validates all <code>ITestContainer</code> implementations end with "Container" <br>suffix<br> <li> Ensures cache key generation works correctly in CI pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/48/files#diff-4e813e5d382279c11680c3440bae668abaacbca407072fbc1d38ec79b908a43b">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-with-coverage.yml</strong><dd><code>Add Docker image caching to test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test-with-coverage.yml

<ul><li>Add Docker image caching step using ScribeMD/docker-cache action<br> <li> Cache key based on hash of <code>*Container.cs</code> files in TestFramework <br>directory<br> <li> Reduce workflow timeout from 30 to 20 minutes<br> <li> Speeds up test execution by reusing cached Docker images</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/48/files#diff-139cbdb0517cef2318b890e6a00e68d937adeb0f8ce8c798d5d8ae144d05c477">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Docker image caching to the CI test workflow, tightens timeout, and updates architecture tests (including a new naming rule for TestContainers).
> 
> - **CI / Workflow (`.github/workflows/test-with-coverage.yml`)**
>   - Add Docker image caching using `ScribeMD/docker-cache` with key from `hashFiles('test/DotNetAtlas.Test.Framework/**/*Container.cs')`.
>   - Reduce job timeout from `30` to `20` minutes.
> - **Architecture Tests**
>   - `test/DotNetAtlas.ArchitectureTests/Application/ApplicationTests.cs`: use `result.FailingTypes.Should().BeEmpty()` for assertions.
>   - `test/DotNetAtlas.ArchitectureTests/CleanArchitecture/CleanArchitectureLayerTests.cs`: switch assertions to `FailingTypes.Should().BeEmpty()`.
>   - `test/DotNetAtlas.ArchitectureTests/BaseTest.cs`: add `TestFrameworkAssembly` via `KafkaTestContainer` reference.
>   - `test/DotNetAtlas.ArchitectureTests/TestFramework/TestContainersNamingTests.cs`: new test enforcing all `ITestContainer` implementations end with `Container`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cb42aeab0f60102260ab3c37d39afe0d73f96a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->