### PR TITLE
ci(workflow): Update permissions for docker cache, run sonar on tag

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -34,6 +34,9 @@ jobs:
 
   test-with-coverage:
     needs: [build-dotnet]
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/test-with-coverage.yml
     with:
       configuration: Release

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -33,6 +33,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      actions: write
     uses: ./.github/workflows/main-ci.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -10,7 +10,7 @@ jobs:
   sonar-cloud-analysis:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    if: github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -30,7 +31,7 @@ jobs:
           CONFIGURATION: ${{ inputs.configuration }}
         run: dotnet build -c "$CONFIGURATION" --no-restore
       - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 #0.6.0
         continue-on-error: true
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('test/DotNetAtlas.Test.Framework/**/*Container.cs') }}


### PR DESCRIPTION
### TL;DR

Updated GitHub workflow permissions and modified SonarCloud analysis trigger condition.

### What changed?

- Added explicit permissions (`contents: read` and `actions: write`) to the `test-with-coverage` job in `main-ci.yml`
- Added the same permissions to the reusable workflow in `test-with-coverage.yml`
- Changed the SonarCloud analysis trigger condition from running on the `main` branch to only running on tag creation (`startsWith(github.ref, 'refs/tags/')`)

### How to test?

1. Create a new tag to verify SonarCloud analysis runs only on tag creation
2. Verify that the `test-with-coverage` job has the proper permissions to read contents and write actions
3. Run the CI workflow to ensure all jobs complete successfully with the updated permissions

### Why make this change?

This change improves the security posture of our GitHub Actions workflows by explicitly defining the minimum required permissions. Additionally, it optimizes our SonarCloud analysis to run only when we create new tags (likely for releases) rather than on every push to main, which reduces unnecessary analysis runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates GitHub Actions permissions, runs SonarCloud only on tag refs, and switches Docker cache action.
> 
> - **Workflows**:
>   - **Permissions**:
>     - `.github/workflows/main-ci.yml`: Add `permissions` (`contents: read`, `actions: write`) to `test-with-coverage` job.
>     - `.github/workflows/test-with-coverage.yml`: Add `permissions` (`contents: read`, `actions: write`) to `test-with-coverage` job.
>     - `.github/workflows/pr-ci.yml`: Add `actions: write` to `run-ci` job permissions.
>   - **SonarCloud**:
>     - `.github/workflows/sonar-cloud-analysis.yml`: Change condition to run only on tag refs (`startsWith(github.ref, 'refs/tags/')`).
>   - **Caching**:
>     - `.github/workflows/test-with-coverage.yml`: Replace Docker cache action with `AndreKurait/docker-cache@0.6.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd14176dba87b751d2def234125171e685dad26e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->