### PR TITLE
feat(outbox): Add OutboxRelay Worker Service for Outbox Message dispatching to Kafka

### DIFF
--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/ConnectionStringsOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/ConnectionStringsOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common.Config;
+
+public class ConnectionStringsOptions
+{
+    public const string Section = "ConnectionStrings";
+
+    [Required(ErrorMessage = $"{nameof(Outbox)} connection string is missing", AllowEmptyStrings = false)]
+    public required string Outbox { get; set; }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/EfCoreOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/EfCoreOptions.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common.Config;
+
+public sealed class EfCoreOptions
+{
+    public const string Section = "EfCore";
+
+    [Required]
+    [Range(1, 10)]
+    public required int DbContextPoolSize { get; set; }
+
+    [Required]
+    [Range(0, 10)]
+    public required int RetryMaxCount { get; set; }
+
+    [Required]
+    [Range(1, 180)]
+    public required int RetryMaxDelaySeconds { get; set; }
+
+    [Required]
+    public required bool EnableDetailedErrors { get; set; }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/HealthChecksOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/HealthChecksOptions.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common.Config;
+
+/// <summary>
+/// Configuration options for health check timeouts.
+/// </summary>
+public sealed class HealthChecksOptions
+{
+    public const string Section = "HealthChecks";
+
+    [Required]
+    [Range(typeof(TimeSpan), "00:00:01", "00:01:00")]
+    public required TimeSpan SelfTimeout { get; set; }
+
+    [Required]
+    [Range(typeof(TimeSpan), "00:00:01", "00:01:00")]
+    public required TimeSpan OutboxRelayExecutionTimeout { get; set; }
+
+    [Required]
+    [Range(typeof(TimeSpan), "00:00:01", "00:01:00")]
+    public required TimeSpan KafkaTimeout { get; set; }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/packages.lock.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/packages.lock.json
@@ -1,0 +1,51 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ=="
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "MnPx3NJT7pLBfOgIVs1/IXL8n5sEErhaJu14TQujaXTMwzv9I3v+nzPqUrUuEunaHeeH10n/3oZBn/Xg4trP0g=="
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "kPhYbH1DmcT1GQUGPQqMGEaQKAGVA31tStPy/ESXPeC8xCVqq7KZg1EKq6XoV4MSgPJ4X/XzZyKHo6Bk8FVbdg=="
+      }
+    },
+    "net10.0/win-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ==",
+        "dependencies": {
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "+oUu2CGnaaWBwFYC3HWXeOeNqBKiE7vdoofgEFrwZXT2m1d03T+DeUSiub5K//Bt9JEZD3/7BfE62k+a5ZRwwA=="
+      }
+    }
+  }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Extensions/HostEnvironmentExtensions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Extensions/HostEnvironmentExtensions.cs
@@ -1,0 +1,34 @@
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common.Extensions;
+
+public static class HostEnvironmentExtensions
+{
+    /// <summary>
+    /// Checks if the current host environment name is Local.
+    /// </summary>
+    /// <param name="hostEnvironment">An instance of <see cref="Microsoft.Extensions.Hosting.IHostEnvironment" />.</param>
+    /// <returns>True if the environment name is Local, otherwise false.</returns>
+    public static bool IsLocal(this IHostEnvironment hostEnvironment)
+    {
+        return hostEnvironment.IsEnvironment("Local");
+    }
+
+    /// <summary>
+    /// Checks if the current host environment name is Testing.
+    /// </summary>
+    /// <param name="hostEnvironment">An instance of <see cref="Microsoft.Extensions.Hosting.IHostEnvironment" />.</param>
+    /// <returns>True if the environment name is Testing, otherwise false.</returns>
+    public static bool IsTesting(this IHostEnvironment hostEnvironment)
+    {
+        return hostEnvironment.IsEnvironment("Testing");
+    }
+
+    /// <summary>
+    /// Checks if the current host environment name is deployed in any non-local cluster.
+    /// </summary>
+    /// <param name="hostEnvironment">An instance of <see cref="Microsoft.Extensions.Hosting.IHostEnvironment" />.</param>
+    /// <returns>True if the environment is in a cluster, otherwise false.</returns>
+    public static bool IsInCluster(this IHostEnvironment hostEnvironment)
+    {
+        return !(hostEnvironment.IsLocal() || hostEnvironment.IsTesting());
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/HealthChecksDependencyInjection.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/HealthChecksDependencyInjection.cs
@@ -1,0 +1,112 @@
+using DotNetAtlas.OutboxRelay.WorkerService.Common.Config;
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.HealthChecks;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Prometheus;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common;
+
+/// <summary>
+/// Dependency injection extensions for health checks infrastructure.
+/// Configures health checks for database, messaging, and service execution monitoring.
+/// </summary>
+public static class HealthChecksDependencyInjection
+{
+    /// <summary>
+    /// Configures health checks for the OutboxRelay worker.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The configuration manager.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHealthChecksInternal(
+        this IServiceCollection services,
+        ConfigurationManager configuration)
+    {
+        services.AddOptionsWithValidateOnStart<OutboxRelayHealthCheckOptions>()
+            .BindConfiguration(OutboxRelayHealthCheckOptions.Section)
+            .ValidateDataAnnotations();
+
+        services.AddOptionsWithValidateOnStart<HealthChecksOptions>()
+            .BindConfiguration(HealthChecksOptions.Section)
+            .ValidateDataAnnotations();
+
+        var timeoutsOptions = configuration
+            .GetRequiredSection(HealthChecksOptions.Section)
+            .Get<HealthChecksOptions>()!;
+
+        var kafkaProducerOptions = configuration
+            .GetRequiredSection(KafkaProducerOptions.Section)
+            .Get<KafkaProducerOptions>()!;
+
+        services.AddHealthChecks()
+            .AddCheck("Self", () => HealthCheckResult.Healthy(),
+                tags: [InfrastructureConstants.LivenessTag, InfrastructureConstants.ReadinessTag],
+                timeout: timeoutsOptions.SelfTimeout)
+            .AddDbContextCheck<OutboxDbContext>(
+                name: "Outbox DbContext",
+                tags:
+                [
+                    InfrastructureConstants.ReadinessTag, InfrastructureConstants.DatabaseTag
+                ],
+                failureStatus: HealthStatus.Unhealthy)
+            .AddKafka(kafkaProducerOptions, "healthchecks", "Kafka",
+                tags:
+                [
+                    InfrastructureConstants.ReadinessTag, InfrastructureConstants.MessagingTag
+                ],
+                failureStatus: HealthStatus.Unhealthy,
+                timeout: timeoutsOptions.KafkaTimeout)
+            .AddCheck<OutboxRelayHealthCheck>(
+                name: "OutboxRelay Execution",
+                tags: [InfrastructureConstants.LivenessTag, InfrastructureConstants.ReadinessTag],
+                failureStatus: HealthStatus.Unhealthy,
+                timeout: timeoutsOptions.OutboxRelayExecutionTimeout);
+        services.AddSingleton<OutboxRelayHealthCheck>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Maps health check endpoints with appropriate filters.
+    /// </summary>
+    /// <param name="app">The web application.</param>
+    /// <returns>The web application for chaining.</returns>
+    public static WebApplication MapHealthChecksInternal(this WebApplication app)
+    {
+        app.MapHealthChecks(InfrastructureConstants.ReadinessEndpointPath, new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains(InfrastructureConstants.ReadinessTag)
+        }).ShortCircuit();
+
+        app.MapHealthChecks(InfrastructureConstants.HealthEndpointPath, new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains(InfrastructureConstants.LivenessTag)
+        }).ShortCircuit();
+
+        return app;
+    }
+
+    public static WebApplication UseHealthChecksPrometheusExporterInternal(this WebApplication app)
+    {
+        // Suppress default prometheus-net collectors and collect only health-related metrics to avoid duplicated scraping.
+        // As of now, there is no standardized way to push health metrics through OTEL Collector
+        // all other collected metrics are unaffected and still exported through OTEL Collector to prometheus.
+        Metrics.SuppressDefaultMetrics();
+
+        app.UseHealthChecksPrometheusExporter(InfrastructureConstants.PrometheusEndpointPath, options =>
+        {
+            options.Predicate = healthCheck => healthCheck.Tags.Contains(InfrastructureConstants.ReadinessTag);
+            options.ResultStatusCodes = new Dictionary<HealthStatus, int>
+            {
+                // Prometheus expects 200 also for degraded state, otherwise throws in the scrape job
+                [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                [HealthStatus.Unhealthy] = StatusCodes.Status200OK
+            };
+        });
+
+        return app;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/InfrastructureConstants.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/InfrastructureConstants.cs
@@ -1,0 +1,15 @@
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common;
+
+public static class InfrastructureConstants
+{
+    private const string ApiBasePath = "/api";
+
+    public const string HealthEndpointPath = $"{ApiBasePath}/healthz";
+    public const string ReadinessEndpointPath = $"{ApiBasePath}/readiness";
+    public const string PrometheusEndpointPath = $"{ApiBasePath}/health/prometheus";
+
+    public const string ReadinessTag = "ready";
+    public const string LivenessTag = "live";
+    public const string DatabaseTag = "database";
+    public const string MessagingTag = "messaging";
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/ObservabilityDependencyInjection.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/ObservabilityDependencyInjection.cs
@@ -1,0 +1,125 @@
+using DotNetAtlas.OutboxRelay.WorkerService.Observability;
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Serilog;
+using Serilog.Sinks.OpenTelemetry;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common;
+
+/// <summary>
+/// Dependency injection extensions for observability infrastructure.
+/// Configures logging (Serilog) and distributed tracing/metrics (OpenTelemetry).
+/// </summary>
+public static class ObservabilityDependencyInjection
+{
+    /// <summary>
+    /// Configures Serilog logging with sinks and enrichers.
+    /// Sets up console and OpenTelemetry sinks based on the environment.
+    /// </summary>
+    /// <param name="builder">The web application builder.</param>
+    /// <param name="isClusterEnvironment">Whether running in a cluster environment.</param>
+    /// <returns>The configured web application builder.</returns>
+    public static WebApplicationBuilder UseSerilogInternal(
+        this WebApplicationBuilder builder,
+        bool isClusterEnvironment)
+    {
+        builder.Host.UseSerilog((context, services, configuration) =>
+        {
+            var oltpExporterEndpoint = context.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+
+            configuration
+                .ReadFrom.Configuration(builder.Configuration)
+                .Enrich.FromLogContext();
+            if (isClusterEnvironment)
+            {
+                configuration.WriteTo.Console();
+            }
+            else
+            {
+                configuration.WriteTo.Console(new ExpressionTemplate(
+                    "[{@t:HH:mm:ss} {@l:u3}] " +
+                    "[{Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}] " +
+                    "{@m}" +
+                    "\n" +
+                    "{@x}",
+                    theme: TemplateTheme.Code));
+
+                if (!string.IsNullOrWhiteSpace(oltpExporterEndpoint))
+                {
+                    configuration.WriteTo.OpenTelemetry(options =>
+                    {
+                        options.Endpoint = oltpExporterEndpoint;
+                        options.ResourceAttributes = new Dictionary<string, object>
+                        {
+                            ["service.name"] = OutboxRelayInstrumentation.AppName
+                        };
+                        options.IncludedData = IncludedData.SpanIdField | IncludedData.TraceIdField |
+                                               IncludedData.SourceContextAttribute;
+                    });
+                }
+            }
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures OpenTelemetry distributed tracing and metrics.
+    /// Sets up instrumentation for ASP.NET Core, HTTP clients, EF Core, SignalR, Redis, and more.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="isClusterEnvironment">Whether running in a cluster environment.</param>
+    /// <param name="configuration">The configuration manager.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddOpenTelemetryInternal(
+        this IServiceCollection services,
+        bool isClusterEnvironment,
+        ConfigurationManager configuration)
+    {
+        services.AddSingleton(TimeProvider.System);
+        services.AddMetrics();
+
+        services.AddOptionsWithValidateOnStart<OutboxMetricsCollectorOptions>()
+            .BindConfiguration(OutboxMetricsCollectorOptions.Section)
+            .ValidateDataAnnotations();
+        services.AddHostedService<OutboxMetricsCollector>();
+        services.AddSingleton<OutboxRelayMetrics>();
+
+        // Be careful of ENV variables overriding what is set in appsettings.json for otel collector
+        // OTEL_EXPORTER_OTLP_ENDPOINT is standardized can be set as ENV e.g., by Rider OpenTelemetry plugin
+        var oltpExporterEndpoint = configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+        if (!string.IsNullOrWhiteSpace(oltpExporterEndpoint))
+        {
+            var otel = services.AddOpenTelemetry()
+                .ConfigureResource(resource => resource
+                    .AddService(serviceName: OutboxRelayInstrumentation.AppName,
+                        serviceVersion: OutboxRelayInstrumentation.Version)
+                    .AddContainerDetector()
+                    .AddHostDetector())
+                .WithTracing(tracing =>
+                {
+                    tracing.AddSource("*");
+
+                    tracing.AddOtlpExporter(options => options.Endpoint = new Uri(oltpExporterEndpoint));
+                })
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddMeter("*")
+                        .AddRuntimeInstrumentation()
+                        .AddProcessInstrumentation();
+
+                    metrics.SetExemplarFilter(isClusterEnvironment
+                        ? ExemplarFilterType.TraceBased
+                        : ExemplarFilterType.AlwaysOn);
+
+                    metrics.AddOtlpExporter(options => options.Endpoint = new Uri(oltpExporterEndpoint));
+                });
+        }
+
+        return services;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/OutboxRelayDependencyInjection.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/OutboxRelayDependencyInjection.cs
@@ -1,0 +1,71 @@
+using Confluent.Kafka;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common;
+
+public static class OutboxRelayDependencyInjection
+{
+    /// <summary>
+    /// Configures Kafka producer and outbox processing services.
+    /// </summary>
+    /// <param name="builder">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static WebApplicationBuilder AddOutboxRelayWorker(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddOptionsWithValidateOnStart<OutboxRelayOptions>()
+            .BindConfiguration(OutboxRelayOptions.Section)
+            .ValidateDataAnnotations();
+
+        builder.Services.AddOptionsWithValidateOnStart<KafkaProducerOptions>()
+            .BindConfiguration(KafkaProducerOptions.Section)
+            .ValidateDataAnnotations();
+
+        var outboxRelayConfig = builder.Configuration
+            .GetSection(OutboxRelayOptions.Section)
+            .Get<OutboxRelayOptions>();
+
+        if (outboxRelayConfig != null)
+        {
+            var hostShutdownTimeout = TimeSpan.FromMilliseconds(
+                outboxRelayConfig.ShutdownTimeoutMs);
+
+            builder.Services.Configure<HostOptions>(options =>
+            {
+                options.ShutdownTimeout = hostShutdownTimeout;
+            });
+
+            Log.Information(
+                "Host shutdown timeout configured to {TimeoutSeconds}s",
+                hostShutdownTimeout.TotalSeconds);
+        }
+
+        builder.Services.AddHostedService<OutboxRelayWorker>();
+        builder.Services.AddSingleton<OutboxMessageRelay>();
+
+        builder.Services.AddSingleton<IProducer<string?, byte[]>>(sp =>
+        {
+            var producerOptions = sp.GetRequiredService<IOptions<KafkaProducerOptions>>().Value;
+            var logger = sp.GetRequiredService<ILogger<Program>>();
+
+            return new ProducerBuilder<string?, byte[]>(producerOptions)
+                .SetLogHandler((producer, logMessage) =>
+                {
+                    var level = logMessage.Level switch
+                    {
+                        SyslogLevel.Emergency or SyslogLevel.Alert or SyslogLevel.Critical => LogLevel.Critical,
+                        SyslogLevel.Error => LogLevel.Error,
+                        SyslogLevel.Warning => LogLevel.Warning,
+                        SyslogLevel.Notice or SyslogLevel.Info => LogLevel.Information,
+                        _ => LogLevel.Debug
+                    };
+                    logger.Log(level, "{ProducerName}: {Message}", producer.Name, logMessage.Message);
+                })
+                .Build();
+        });
+
+        return builder;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/PersistenceDependencyInjection.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Common/PersistenceDependencyInjection.cs
@@ -1,0 +1,52 @@
+using DotNetAtlas.Outbox.EntityFrameworkCore.EntityFramework;
+using DotNetAtlas.OutboxRelay.WorkerService.Common.Config;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Common;
+
+/// <summary>
+/// Dependency injection extensions for persistence infrastructure.
+/// Configures database (EF Core) and distributed caching (Redis + FusionCache).
+/// </summary>
+public static class PersistenceDependencyInjection
+{
+    /// <summary>
+    /// Configures Entity Framework Core database context with SQL Server.
+    /// Sets up connection pooling, interceptors, retry policies, seeding, and outbox pattern.
+    /// </summary>
+    public static IServiceCollection AddDatabase(
+        this IServiceCollection services,
+        ConfigurationManager configuration)
+    {
+        services.AddOptionsWithValidateOnStart<EfCoreOptions>()
+            .BindConfiguration(EfCoreOptions.Section)
+            .ValidateDataAnnotations();
+
+        var efCoreOptions = configuration
+            .GetRequiredSection(EfCoreOptions.Section)
+            .Get<EfCoreOptions>()!;
+
+        services
+            .AddOptionsWithValidateOnStart<ConnectionStringsOptions>()
+            .BindConfiguration(ConnectionStringsOptions.Section)
+            .ValidateDataAnnotations();
+
+        services.AddPooledDbContextFactory<OutboxDbContext>(options =>
+                options.UseSqlServer(
+                        configuration.GetConnectionString(nameof(ConnectionStringsOptions.Outbox)),
+                        sqlServerOptions =>
+                        {
+                            sqlServerOptions.EnableRetryOnFailure(
+                                maxRetryCount: efCoreOptions.RetryMaxCount,
+                                maxRetryDelay: TimeSpan.FromSeconds(efCoreOptions.RetryMaxDelaySeconds),
+                                errorNumbersToAdd: null);
+                        })
+                    .EnableDetailedErrors(efCoreOptions.EnableDetailedErrors),
+            poolSize: efCoreOptions.DbContextPoolSize);
+
+        services.AddScoped<IOutboxDbContext, OutboxDbContext>();
+
+        return services;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Dockerfile
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Dockerfile
@@ -1,0 +1,56 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.0-rc.1-noble-chiseled-extra@sha256:83795c4b066ec5f0610d8c3fdd977b65e7536c9bbade4f594e80e5fa24fb533a AS base
+USER $APP_UID
+WORKDIR /app
+ENV ASPNETCORE_URLS=http://+:8080 \
+    DOTNET_gcServer=1 \
+    DOTNET_TieredPGO=1
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0.100-rc.1-noble@sha256:eee11b0bf11715710bbe8339b9641f0ef8b5d8a8e07f2d6ff3cd4361c1a4e5a7 AS build
+ARG BUILD_CONFIGURATION=Release
+ARG VERSION=0.0.0
+ARG ASSEMBLY_VERSION=0.0.0.0
+ARG FILE_VERSION=0.0.0.0
+ARG INFORMATIONAL_VERSION=0.0.0
+ARG RUNTIME_ID=linux-x64
+WORKDIR /workspace
+
+# Copy NuGet config and project files to leverage Docker layer cache
+COPY NuGet.config .
+COPY Directory.Build.props .
+COPY Directory.Packages.props .
+COPY global.json .
+COPY platform/DotNetAtlas.Outbox.Core/DotNetAtlas.Outbox.Core.csproj platform/DotNetAtlas.Outbox.Core/
+COPY platform/DotNetAtlas.Outbox.EntityFrameworkCore/DotNetAtlas.Outbox.EntityFrameworkCore.csproj platform/DotNetAtlas.Outbox.EntityFrameworkCore/
+COPY platform/DotNetAtlas.OutboxRelay.WorkerService/DotNetAtlas.OutboxRelay.WorkerService.csproj platform/DotNetAtlas.OutboxRelay.WorkerService/
+
+# Restore with cache mounts
+RUN dotnet restore --locked-mode -p:PublishReadyToRun=true platform/DotNetAtlas.OutboxRelay.WorkerService/DotNetAtlas.OutboxRelay.WorkerService.csproj
+
+# Copy the worker service source files
+COPY . .
+WORKDIR /workspace/platform/DotNetAtlas.OutboxRelay.WorkerService
+
+# Ensure full restore after copying all sources (includes analyzers/source generators)
+RUN dotnet restore --locked-mode -p:PublishReadyToRun=true DotNetAtlas.OutboxRelay.WorkerService.csproj
+
+# Build without restore; cache NuGet packages
+RUN dotnet build DotNetAtlas.OutboxRelay.WorkerService.csproj -c $BUILD_CONFIGURATION -r $RUNTIME_ID --no-restore -o /app/build \
+    -p:Version=$VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:FileVersion=$FILE_VERSION -p:InformationalVersion=$INFORMATIONAL_VERSION
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+ARG VERSION=0.0.0
+ARG ASSEMBLY_VERSION=0.0.0.0
+ARG FILE_VERSION=0.0.0.0
+ARG INFORMATIONAL_VERSION=0.0.0
+ARG RUNTIME_ID=linux-x64
+WORKDIR /workspace/platform/DotNetAtlas.OutboxRelay.WorkerService
+RUN dotnet publish DotNetAtlas.OutboxRelay.WorkerService.csproj -c $BUILD_CONFIGURATION -r $RUNTIME_ID -o /app/publish \
+    -p:RestoreLockedMode=true -p:UseAppHost=false -p:PublishReadyToRun=true -p:Version=$VERSION -p:AssemblyVersion=$ASSEMBLY_VERSION -p:FileVersion=$FILE_VERSION -p:InformationalVersion=$INFORMATIONAL_VERSION
+
+FROM base AS final
+WORKDIR /app
+
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "DotNetAtlas.OutboxRelay.WorkerService.dll"]

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/DotNetAtlas.OutboxRelay.WorkerService.csproj
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/DotNetAtlas.OutboxRelay.WorkerService.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Build.Tasks.Core"/>
+
+        <!-- Logging -->
+        <PackageReference Include="Serilog.AspNetCore"/>
+        <PackageReference Include="Serilog.Sinks.Console"/>
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry"/>
+        <PackageReference Include="Serilog.Expressions"/>
+
+        <!-- Database -->
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+
+        <!-- Health Checks -->
+        <PackageReference Include="AspNetCore.HealthChecks.Kafka"/>
+        <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"/>
+
+        <!-- OpenTelemetry -->
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Process"/>
+        <PackageReference Include="OpenTelemetry.Resources.Container"/>
+        <PackageReference Include="OpenTelemetry.Resources.Host"/>
+
+        <PackageReference Include="StyleCop.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="DotNetAtlas.OutboxRelay.Benchmark"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DotNetAtlas.Outbox.Core\DotNetAtlas.Outbox.Core.csproj"/>
+        <ProjectReference Include="..\DotNetAtlas.Outbox.EntityFrameworkCore\DotNetAtlas.Outbox.EntityFrameworkCore.csproj" />
+    </ItemGroup>
+</Project>

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheck.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheck.cs
@@ -1,0 +1,77 @@
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.HealthChecks;
+
+/// <summary>
+/// Health check that monitors the OutboxRelay service execution.
+/// Reports unhealthy if the service hasn't run within the expected time window.
+/// </summary>
+public sealed class OutboxRelayHealthCheck : IHealthCheck
+{
+    private readonly OutboxRelayHealthCheckOptions _outboxRelayHealthCheckOptions;
+    private readonly TimeSpan _degradedThreshold;
+    private readonly TimeSpan _unhealthyThreshold;
+    private readonly TimeProvider _timeProvider;
+    private readonly OutboxRelayMetrics _outboxRelayMetrics;
+
+    public OutboxRelayHealthCheck(
+        IOptions<OutboxRelayHealthCheckOptions> healthCheckOptions,
+        IOptions<OutboxRelayOptions> outboxRelayOptions,
+        TimeProvider timeProvider,
+        OutboxRelayMetrics outboxRelayMetrics)
+    {
+        _timeProvider = timeProvider;
+        _outboxRelayHealthCheckOptions = healthCheckOptions.Value;
+        _outboxRelayMetrics = outboxRelayMetrics;
+
+        var pollingIntervalMs = outboxRelayOptions.Value.PollingIntervalMs;
+
+        _degradedThreshold = TimeSpan.FromMilliseconds(Math.Max(
+            pollingIntervalMs * _outboxRelayHealthCheckOptions.DegradedThresholdMultiplier,
+            _outboxRelayHealthCheckOptions.MinimumDegradedThreshold.TotalMilliseconds));
+
+        _unhealthyThreshold = TimeSpan.FromMilliseconds(Math.Max(
+            pollingIntervalMs * _outboxRelayHealthCheckOptions.UnhealthyThresholdMultiplier,
+            _outboxRelayHealthCheckOptions.MinimumUnhealthyThreshold.TotalMilliseconds));
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // If never executed successfully, check if we're still in a startup grace period
+        if (_outboxRelayMetrics.LastSuccessfulExecution == DateTimeOffset.MinValue)
+        {
+            var uptime = _timeProvider.GetUtcNow() - _outboxRelayHealthCheckOptions.ServiceStartTime;
+            if (uptime >= _outboxRelayHealthCheckOptions.StartupGracePeriod)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy(
+                    "Service has never completed a successful execution"));
+            }
+
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"Service is starting up (grace period: {_outboxRelayHealthCheckOptions.StartupGracePeriod.TotalSeconds}s)"));
+        }
+
+        var timeSinceLastExecution = _timeProvider.GetUtcNow() - _outboxRelayMetrics.LastSuccessfulExecution;
+        if (timeSinceLastExecution > _unhealthyThreshold)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Service hasn't executed successfully for {timeSinceLastExecution.TotalSeconds:F1} seconds " +
+                $"(threshold: {_unhealthyThreshold.TotalSeconds:F1} seconds)"));
+        }
+
+        if (timeSinceLastExecution > _degradedThreshold)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                $"Service hasn't executed successfully for {timeSinceLastExecution.TotalSeconds:F1} seconds " +
+                $"(threshold: {_degradedThreshold.TotalSeconds:F1} seconds)"));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Service is healthy. Last execution: {timeSinceLastExecution.TotalSeconds:F1} seconds ago"));
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheckOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheckOptions.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.HealthChecks;
+
+/// <summary>
+/// Configuration options for the OutboxRelay health check.
+/// </summary>
+public sealed class OutboxRelayHealthCheckOptions : IValidatableObject
+{
+    public const string Section = "OutboxRelayHealthCheck";
+
+    /// <summary>
+    /// How long to wait during startup before considering the service unhealthy if it hasn't executed.
+    /// </summary>
+    [Required]
+    [Range(typeof(TimeSpan), "00:01:00", "00:30:00")]
+    public required TimeSpan StartupGracePeriod { get; set; }
+
+    /// <summary>
+    /// Multiplier for the polling interval to determine the degraded threshold.
+    /// Must be greater than 1.0 to be meaningful.
+    /// </summary>
+    [Required]
+    [Range(1.1, 10.0)]
+    public required double DegradedThresholdMultiplier { get; set; }
+
+    /// <summary>
+    /// Multiplier for the polling interval to determine an unhealthy threshold.
+    /// Must be greater than DegradedThresholdMultiplier.
+    /// </summary>
+    [Required]
+    [Range(1.2, 20.0)]
+    public required double UnhealthyThresholdMultiplier { get; set; }
+
+    /// <summary>
+    /// Minimum degraded threshold (floor value). Prevents thresholds from being too short for fast polling.
+    /// </summary>
+    [Required]
+    [Range(typeof(TimeSpan), "00:00:05", "00:10:00")]
+    public required TimeSpan MinimumDegradedThreshold { get; set; }
+
+    /// <summary>
+    /// Minimum unhealthy threshold (floor value). Prevents thresholds from being too short for fast polling.
+    /// Must be greater than the MinimumDegradedThreshold.
+    /// </summary>
+    [Required]
+    [Range(typeof(TimeSpan), "00:00:10", "00:30:00")]
+    public required TimeSpan MinimumUnhealthyThreshold { get; set; }
+
+    /// <summary>
+    /// When the service started (set by the health check registration).
+    /// </summary>
+    public DateTimeOffset ServiceStartTime { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Custom validation to ensure logical consistency between thresholds.
+    /// </summary>
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var results = new List<ValidationResult>();
+
+        if (UnhealthyThresholdMultiplier <= DegradedThresholdMultiplier)
+        {
+            results.Add(new ValidationResult(
+                "UnhealthyThresholdMultiplier must be greater than DegradedThresholdMultiplier.",
+                [nameof(UnhealthyThresholdMultiplier)]));
+        }
+
+        if (MinimumUnhealthyThreshold <= MinimumDegradedThreshold)
+        {
+            results.Add(new ValidationResult(
+                "MinimumUnhealthyThreshold must be greater than MinimumDegradedThreshold.",
+                [nameof(MinimumUnhealthyThreshold)]));
+        }
+
+        return results;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollector.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollector.cs
@@ -1,0 +1,102 @@
+using DotNetAtlas.Outbox.EntityFrameworkCore.EntityFramework;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+
+public sealed class OutboxMetricsCollector : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly OutboxRelayMetrics _outboxRelayMetrics;
+    private readonly OutboxMetricsCollectorOptions _outboxMetricsCollectorOptions;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<OutboxMetricsCollector> _logger;
+
+    public OutboxMetricsCollector(
+        OutboxRelayMetrics outboxRelayMetrics,
+        IOptions<OutboxMetricsCollectorOptions> options,
+        ILogger<OutboxMetricsCollector> logger,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider)
+    {
+        _outboxRelayMetrics = outboxRelayMetrics;
+        _outboxMetricsCollectorOptions = options.Value;
+        _logger = logger;
+        _scopeFactory = scopeFactory;
+        _timeProvider = timeProvider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "Outbox metrics monitoring started with update interval: {ReportIntervalSeconds}s",
+            _outboxMetricsCollectorOptions.ReportIntervalSeconds);
+
+        using var timer =
+            new PeriodicTimer(TimeSpan.FromSeconds(_outboxMetricsCollectorOptions.ReportIntervalSeconds));
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await ReportOutboxMetrics(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update outbox metrics");
+            }
+        }
+
+        _logger.LogInformation("Outbox metrics monitoring stopped");
+    }
+
+    private async Task ReportOutboxMetrics(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var outboxDbContext = scope.ServiceProvider.GetRequiredService<IOutboxDbContext>();
+
+        var oldestMessageCreated = await outboxDbContext.OutboxMessages
+            .OrderBy(m => m.Id)
+            .Select(m => m.CreatedUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var newestMessageCreated = await outboxDbContext.OutboxMessages
+            .OrderByDescending(m => m.Id)
+            .Select(m => m.CreatedUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (oldestMessageCreated != default)
+        {
+            var outboxTailLag = _timeProvider.GetUtcNow() - oldestMessageCreated;
+            var tailLagMs = (long)outboxTailLag.TotalMilliseconds;
+            _outboxRelayMetrics.SetOutboxTailLagMs(tailLagMs);
+
+            _logger.LogDebug(
+                "Updated outbox tail lag metric: {LagMs}ms (oldest message from {CreatedAt})",
+                tailLagMs, oldestMessageCreated);
+        }
+        else
+        {
+            _outboxRelayMetrics.SetOutboxTailLagMs(0);
+            _logger.LogDebug("Outbox is empty, tail lag metric set to 0ms");
+        }
+
+        if (newestMessageCreated != default)
+        {
+            var outboxHeadLag = _timeProvider.GetUtcNow() - newestMessageCreated;
+            var headLagMs = (long)outboxHeadLag.TotalMilliseconds;
+            _outboxRelayMetrics.SetOutboxHeadLagMs(headLagMs);
+
+            _logger.LogDebug(
+                "Updated outbox head lag metric: {LagMs}ms (newest message from {CreatedAt})",
+                headLagMs, newestMessageCreated);
+        }
+        else
+        {
+            _outboxRelayMetrics.SetOutboxHeadLagMs(0);
+            _logger.LogDebug("Outbox is empty, head lag metric set to 0ms");
+        }
+
+        var pendingCount = await outboxDbContext.OutboxMessages.CountAsync(cancellationToken);
+        _outboxRelayMetrics.SetOutboxPendingMessages(pendingCount);
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollectorOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollectorOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+
+/// <summary>
+/// Configuration options for outbox metrics monitoring.
+/// </summary>
+public sealed class OutboxMetricsCollectorOptions
+{
+    public const string Section = "OutboxMetricsCollector";
+
+    /// <summary>
+    /// Interval in seconds at which to update outbox size metrics.
+    /// </summary>
+    [Required]
+    [Range(1, 300, ErrorMessage = "Metrics reporting interval must be between 1 and 300 seconds")]
+    public required int ReportIntervalSeconds { get; set; }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetricConstants.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetricConstants.cs
@@ -1,0 +1,35 @@
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+
+/// <summary>
+/// Constants for OutboxRelay metric tag keys and values.
+/// Follows Prometheus naming conventions and OpenTelemetry semantic conventions.
+/// </summary>
+internal static class OutboxRelayMetricConstants
+{
+    /// <summary>
+    /// Tag keys for metric dimensions.
+    /// </summary>
+    public static class Tags
+    {
+        public const string MessageType = "message_type";
+        public const string ProcessedCount = "processed_count";
+    }
+
+    /// <summary>
+    /// Tag values for processed count categories.
+    /// </summary>
+    public static class ProcessedCountValues
+    {
+        public const string None = "none";
+        public const string Single = "single";
+        public const string Tiny = "tiny";
+        public const string Small = "small";
+        public const string Medium = "medium";
+        public const string Large = "large";
+        public const string XLarge = "xlarge";
+        public const string XxLarge = "xxlarge";
+        public const string Huge = "huge";
+        public const string Massive = "massive";
+        public const string Gigantic = "gigantic";
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetrics.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetrics.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics.Metrics;
+
+// ReSharper disable NotAccessedField.Local -> observable metrics
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+
+/// <summary>
+/// Custom metrics for OutboxRelay service monitoring.
+/// </summary>
+public sealed class OutboxRelayMetrics
+{
+    private readonly Counter<long> _messagesPublishedCounter;
+    private readonly Counter<long> _messagesFailedCounter;
+    private readonly Histogram<double> _processingDurationHistogram;
+    private readonly ObservableGauge<long> _outboxSizeGauge;
+    private readonly ObservableGauge<long> _outboxHeadLagGauge;
+    private readonly ObservableGauge<long> _outboxTailLagGauge;
+    private readonly ObservableGauge<double> _timeSinceLastExecutionGauge;
+    private long _currentOutboxPendingMessages;
+    private long _currentOutboxHeadLagMs;
+    private long _currentOutboxTailLagMs;
+    public DateTimeOffset LastSuccessfulExecution { get; private set; } = DateTimeOffset.MinValue;
+
+    public OutboxRelayMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(OutboxRelayInstrumentation.AppName);
+
+        _messagesPublishedCounter = meter.CreateCounter<long>(
+            "outbox_messages_published_total",
+            description: "Total number of outbox messages successfully published to Kafka",
+            unit: "{messages}");
+
+        _messagesFailedCounter = meter.CreateCounter<long>(
+            "outbox_messages_failed_total",
+            description: "Total number of outbox messages that failed to publish",
+            unit: "{messages}");
+
+        _processingDurationHistogram = meter.CreateHistogram<double>(
+            "outbox_processing_duration_seconds",
+            description: "Time taken to process outbox message batches",
+            unit: "s");
+
+        _outboxSizeGauge = meter.CreateObservableGauge(
+            "outbox_size_messages",
+            description: "Current size of outbox table (number of pending messages)",
+            unit: "{messages}",
+            observeValue: () => _currentOutboxPendingMessages);
+
+        _outboxHeadLagGauge = meter.CreateObservableGauge(
+            "outbox_head_lag_milliseconds",
+            description: "Lag of newest outbox message (head of queue) in milliseconds",
+            unit: "ms",
+            observeValue: () => _currentOutboxHeadLagMs);
+
+        _outboxTailLagGauge = meter.CreateObservableGauge(
+            "outbox_tail_lag_milliseconds",
+            description: "Lag of oldest outbox message (tail of queue) in milliseconds",
+            unit: "ms",
+            observeValue: () => _currentOutboxTailLagMs);
+
+        _timeSinceLastExecutionGauge = meter.CreateObservableGauge(
+            "outbox_time_since_last_successful_execution_seconds",
+            description: "Time since last successful outbox processing execution",
+            unit: "s",
+            observeValue: () =>
+                LastSuccessfulExecution == DateTimeOffset.MinValue
+                    ? double.NaN
+                    : (DateTimeOffset.UtcNow - LastSuccessfulExecution).TotalSeconds);
+    }
+
+    public void RecordMessagesPublished(int count, string messageType)
+    {
+        _messagesPublishedCounter.Add(count,
+            new KeyValuePair<string, object?>(OutboxRelayMetricConstants.Tags.MessageType, messageType));
+    }
+
+    public void RecordMessagesFailed(int count, string messageType)
+    {
+        _messagesFailedCounter.Add(count,
+            new KeyValuePair<string, object?>(OutboxRelayMetricConstants.Tags.MessageType, messageType));
+    }
+
+    public void RecordSuccessfulExecution() => LastSuccessfulExecution = DateTimeOffset.UtcNow;
+
+    public void RecordProcessingDuration(TimeSpan duration, int processedCount)
+    {
+        if (processedCount > 0)
+        {
+            _processingDurationHistogram.Record(
+                duration.TotalSeconds,
+                new KeyValuePair<string, object?>(
+                    OutboxRelayMetricConstants.Tags.ProcessedCount,
+                    GetProcessedCountCategory(processedCount)));
+        }
+    }
+
+    public void SetOutboxPendingMessages(long size) => _currentOutboxPendingMessages = size;
+    public void SetOutboxHeadLagMs(long lagMs) => _currentOutboxHeadLagMs = lagMs;
+    public void SetOutboxTailLagMs(long lagMs) => _currentOutboxTailLagMs = lagMs;
+
+    private static string GetProcessedCountCategory(int processedCount)
+    {
+        return processedCount switch
+        {
+            0 => OutboxRelayMetricConstants.ProcessedCountValues.None,
+            1 => OutboxRelayMetricConstants.ProcessedCountValues.Single,
+            <= 5 => OutboxRelayMetricConstants.ProcessedCountValues.Tiny,
+            <= 10 => OutboxRelayMetricConstants.ProcessedCountValues.Small,
+            <= 25 => OutboxRelayMetricConstants.ProcessedCountValues.Medium,
+            <= 50 => OutboxRelayMetricConstants.ProcessedCountValues.Large,
+            <= 100 => OutboxRelayMetricConstants.ProcessedCountValues.XLarge,
+            <= 250 => OutboxRelayMetricConstants.ProcessedCountValues.XxLarge,
+            <= 500 => OutboxRelayMetricConstants.ProcessedCountValues.Huge,
+            <= 1000 => OutboxRelayMetricConstants.ProcessedCountValues.Massive,
+            _ => OutboxRelayMetricConstants.ProcessedCountValues.Gigantic
+        };
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/OutboxRelayInstrumentation.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/OutboxRelayInstrumentation.cs
@@ -1,0 +1,11 @@
+using System.Reflection;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability;
+
+public static class OutboxRelayInstrumentation
+{
+    public static readonly AssemblyName AssemblyName = typeof(OutboxRelayInstrumentation).Assembly.GetName();
+    public static readonly string Version = AssemblyName.Version!.ToString();
+
+    public static readonly string AppName = AssemblyName.Name!;
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/KafkaProducerDiagnostics.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/KafkaProducerDiagnostics.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using Confluent.Kafka;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Tracing;
+
+/// <summary>
+/// Provides production-essential OpenTelemetry diagnostics for Kafka producer operations.
+/// Only includes essential OTEL semantic conventions to minimize performance impact.
+/// </summary>
+public static class KafkaProducerDiagnostics
+{
+    private static readonly TextMapPropagator OtelPropagator = Propagators.DefaultTextMapPropagator;
+
+    /// <summary>
+    /// Starts an activity for Kafka message production following OTEL semantic conventions.
+    /// Restores trace context from the original outbox message if available.
+    /// </summary>
+    /// <param name="topic">The Kafka topic name.</param>
+    /// <param name="message">The Kafka message being produced.</param>
+    /// <param name="messageHeaders">Deserialized outbox message headers.</param>
+    /// <returns>Activity for the producer operation, or null if activities are not enabled.</returns>
+    internal static Activity? StartProduceActivity(
+        string topic,
+        Message<string?, byte[]> message,
+        Dictionary<string, string>? messageHeaders)
+    {
+        var activityName = string.Intern($"{topic} {OutboxDiagnosticNames.Kafka.Publish}");
+
+        var parentContext = OtelPropagator.Extract(
+            new PropagationContext(default, Baggage.Current),
+            messageHeaders,
+            ExtractHeader);
+
+        var activity = OutboxRelayActivitySource.ActivitySource.CreateActivity(
+            activityName,
+            ActivityKind.Producer,
+            parentContext.ActivityContext);
+
+        if (activity == null)
+        {
+            return null;
+        }
+
+        // See https://opentelemetry.io/docs/specs/semconv/messaging/kafka/ - production-essential tags only
+        activity.SetTag(OutboxDiagnosticNames.Messaging.System, "kafka");
+        activity.SetTag(OutboxDiagnosticNames.Messaging.Operation, OutboxDiagnosticNames.Kafka.Publish);
+        activity.SetTag(OutboxDiagnosticNames.Messaging.DestinationKind, "topic");
+        activity.SetTag(OutboxDiagnosticNames.Messaging.DestinationName, topic);
+
+        if (message.Key != null)
+        {
+            activity.SetTag(OutboxDiagnosticNames.Kafka.MessageKey, message.Key);
+        }
+
+        activity.SetTag(OutboxDiagnosticNames.Messaging.MessageBodySize, message.Value.Length);
+
+        activity.Start();
+
+        return activity;
+    }
+
+    private static IEnumerable<string> ExtractHeader(Dictionary<string, string>? headers, string key)
+    {
+        if (headers != null && headers.TryGetValue(key, out var value))
+        {
+            return [value];
+        }
+
+        return [];
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxDiagnosticNames.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxDiagnosticNames.cs
@@ -1,0 +1,54 @@
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Tracing;
+
+/// <summary>
+/// Diagnostic names and constants for OutboxRelay service observability.
+/// Follows OpenTelemetry semantic conventions.
+/// </summary>
+public static class OutboxDiagnosticNames
+{
+    /// <summary>
+    /// Messaging system attributes following OTEL semantic conventions.
+    /// </summary>
+    public static class Messaging
+    {
+        /// <summary>
+        /// The messaging system being used (e.g., "kafka").
+        /// </summary>
+        public const string System = "messaging.system";
+
+        /// <summary>
+        /// The messaging operation being performed (e.g., "publish", "process").
+        /// </summary>
+        public const string Operation = "messaging.operation";
+
+        /// <summary>
+        /// The kind of message destination (e.g., "topic", "queue").
+        /// </summary>
+        public const string DestinationKind = "messaging.destination.kind";
+
+        /// <summary>
+        /// The name of the message destination (e.g., topic name).
+        /// </summary>
+        public const string DestinationName = "messaging.destination.name";
+
+        /// <summary>
+        /// The size of the message body in bytes.
+        /// </summary>
+        public const string MessageBodySize = "messaging.message.body.size";
+    }
+
+    /// <summary>
+    /// Kafka-specific attributes following OTEL semantic conventions.
+    /// </summary>
+    public static class Kafka
+    {
+        public const string Publish = "publish";
+        public const string MessageKey = "messaging.kafka.message.key";
+        public const string MessageOffset = "messaging.kafka.message.offset";
+    }
+
+    public static class ErrorTag
+    {
+        public const string Type = "error.type";
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxRelayActivitySource.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxRelayActivitySource.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.Observability.Tracing;
+
+public static class OutboxRelayActivitySource
+{
+    /// <summary>
+    /// Gets the activity source for OutboxRelay operations.
+    /// </summary>
+    public static ActivitySource ActivitySource { get; }
+        = new(OutboxRelayInstrumentation.AppName, OutboxRelayInstrumentation.Version);
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/KafkaProducerOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/KafkaProducerOptions.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using Confluent.Kafka;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+
+/// <summary>
+/// Kafka producer configuration for outbox relay.
+/// Inherits from ProducerConfig to expose all Confluent.Kafka producer settings.
+/// </summary>
+/// <remarks>
+/// Recommended read: https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Producer.
+/// </remarks>
+public sealed class KafkaProducerOptions : ProducerConfig
+{
+    public const string Section = "KafkaProducer";
+
+    /// <summary>
+    /// Client ID for identifying the producer.
+    /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    public new required string ClientId { get; set; }
+
+    /// <summary>
+    /// Kafka Bootstrap Servers.
+    /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    public new required string BootstrapServers { get; set; }
+
+    /// <summary>
+    /// Compression algorithm for messages.
+    /// Options: None, Gzip, Snappy, Lz4, Zstd.
+    /// </summary>
+    [Required]
+    public new required CompressionType? CompressionType { get; set; }
+
+    /// <summary>
+    /// Number of acknowledgments the producer requires before considering a request complete.
+    /// Options: None (0), Leader (1), All (-1).
+    /// </summary>
+    [Required]
+    public new required Acks? Acks { get; set; }
+
+    /// <summary>
+    /// Enable idempotent producer (exactly-once semantics).
+    /// </summary>
+    [Required]
+    public new required bool? EnableIdempotence { get; set; }
+
+    /// <summary>
+    /// Maximum number of in-flight requests per connection.
+    /// Default: 5.
+    /// </summary>
+    public new int? MaxInFlight { get; set; }
+
+    /// <summary>
+    /// Time to wait before sending messages to batch them together (milliseconds).
+    /// Default: 5.
+    /// </summary>
+    public new int? LingerMs { get; set; }
+
+    /// <summary>
+    /// Maximum size of a single batch (bytes).
+    /// </summary>
+    public new int? BatchSize { get; set; }
+
+    /// <summary>
+    /// Local message timeout (milliseconds).
+    /// Default: 300000 (5 minutes).
+    /// </summary>
+    public new int? MessageTimeoutMs { get; set; }
+
+    /// <summary>
+    /// Request timeout for broker communication (milliseconds).
+    /// Default: 30000 (30 seconds).
+    /// </summary>
+    public new int? RequestTimeoutMs { get; set; }
+
+    /// <summary>
+    /// Maximum number of times to retry sending a message.
+    /// Default: 10.
+    /// </summary>
+    public new int? MessageSendMaxRetries { get; set; }
+
+    /// <summary>
+    /// Backoff time between retries (milliseconds).
+    /// Default: 100.
+    /// </summary>
+    public new int? RetryBackoffMs { get; set; }
+
+    public KafkaProducerOptions ShallowClone() => (KafkaProducerOptions)MemberwiseClone();
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/OutboxRelayOptions.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/OutboxRelayOptions.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+
+/// <summary>
+/// Configuration options for the OutboxRelay background service.
+/// </summary>
+public sealed class OutboxRelayOptions : IValidatableObject
+{
+    public const string Section = "OutboxRelay";
+
+    /// <summary>
+    /// How often to poll for new outbox messages (milliseconds).
+    /// </summary>
+    [Required]
+    [Range(100, 300_000)]
+    public required int PollingIntervalMs { get; set; }
+
+    /// <summary>
+    /// Maximum number of messages to process in one batch.
+    /// </summary>
+    [Required]
+    [Range(1, 10_000)]
+    public required int BatchSize { get; set; }
+
+    /// <summary>
+    /// Default Kafka topic to publish outbox messages to when no type-specific mapping is found.
+    /// </summary>
+    [Required]
+    [Length(1, 249)]
+    public required string DefaultTopicName { get; set; }
+
+    /// <summary>
+    /// Dictionary mapping Avro type names to specific Kafka topics.
+    /// Type-specific mappings take precedence over DefaultTopicName.
+    /// Key: Avro type name (e.g., "FeedbackChangedEvent")
+    /// Value: Kafka topic name.
+    /// </summary>
+    public Dictionary<string, string> TypeTopicMappings { get; set; } = [];
+
+    /// <summary>
+    /// Database schema name where the outbox table is located.
+    /// Defaults to "dbo" if not specified.
+    /// </summary>
+    [Required]
+    [RegularExpression("^[a-zA-Z][a-zA-Z0-9_]*$", ErrorMessage = "Schema name must be a valid SQL identifier")]
+    [Length(1, 128)]
+    public required string SchemaName { get; set; }
+
+    /// <summary>
+    /// Database table name for the outbox messages.
+    /// Defaults to "OutboxMessages" if not specified.
+    /// </summary>
+    [Required]
+    [RegularExpression("^[a-zA-Z][a-zA-Z0-9_]*$", ErrorMessage = "Table name must be a valid SQL identifier")]
+    [Length(1, 128)]
+    public required string TableName { get; set; }
+
+    /// <summary>
+    /// Timeout for Kafka producer flush operations in milliseconds.
+    /// Used for both normal batch processing and graceful shutdown flush.
+    /// Must be less than ShutdownTimeoutMs to allow sufficient time for graceful shutdown.
+    /// </summary>
+    [Range(5000, 120_000)]
+    public required int FlushTimeoutMs { get; set; }
+
+    /// <summary>
+    /// Total timeout for graceful shutdown in milliseconds.
+    /// Defines how long the worker waits for final batch processing and producer flush.
+    /// Must be larger than FlushTimeoutMs to allow for cleanup.
+    /// </summary>
+    [Range(10_000, 180_000)]
+    public required int ShutdownTimeoutMs { get; set; }
+
+    public OutboxRelayOptions ShallowClone()
+    {
+        var clone = (OutboxRelayOptions)MemberwiseClone();
+        clone.TypeTopicMappings = new Dictionary<string, string>(TypeTopicMappings);
+
+        return clone;
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var results = new List<ValidationResult>();
+
+        if (FlushTimeoutMs >= ShutdownTimeoutMs)
+        {
+            results.Add(new ValidationResult(
+                $"{nameof(FlushTimeoutMs)} ({FlushTimeoutMs}ms) must be less than {nameof(ShutdownTimeoutMs)} " +
+                $"({ShutdownTimeoutMs}ms) to allow sufficient time for graceful shutdown operations.",
+                [nameof(FlushTimeoutMs), nameof(ShutdownTimeoutMs)]));
+        }
+
+        return results;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxDbContext.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxDbContext.cs
@@ -1,0 +1,31 @@
+using DotNetAtlas.Outbox.Core;
+using DotNetAtlas.Outbox.EntityFrameworkCore.EntityConfiguration;
+using DotNetAtlas.Outbox.EntityFrameworkCore.EntityFramework;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+
+public sealed class OutboxDbContext : DbContext, IOutboxDbContext
+{
+    private readonly OutboxRelayOptions _outboxRelayOptions;
+
+    public OutboxDbContext(
+        DbContextOptions<OutboxDbContext> options,
+        IOptions<OutboxRelayOptions> outboxRelayOptions)
+        : base(options)
+    {
+        _outboxRelayOptions = outboxRelayOptions.Value;
+    }
+
+    public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfiguration(
+            new OutboxMessageConfiguration(_outboxRelayOptions.SchemaName, _outboxRelayOptions.TableName));
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxMessageRelay.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxMessageRelay.cs
@@ -1,0 +1,308 @@
+using System.Diagnostics;
+using System.Text;
+using Confluent.Kafka;
+using DotNetAtlas.Outbox.Core;
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.Tracing;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+
+public sealed class OutboxMessageRelay : IDisposable
+{
+    private const string LastSentIdCacheKey = "OutboxProcessor_LastSentId";
+
+    private readonly IDbContextFactory<OutboxDbContext> _dbContextFactory;
+    private readonly IProducer<string?, byte[]> _kafkaProducer;
+    private readonly OutboxRelayOptions _outboxRelayOptions;
+    private readonly ILogger<OutboxMessageRelay> _logger;
+    private readonly OutboxRelayMetrics _outboxRelayMetrics;
+    private readonly IMemoryCache _memoryCache;
+    private bool _disposed;
+
+    public OutboxMessageRelay(
+        IDbContextFactory<OutboxDbContext> dbContextFactory,
+        IProducer<string?, byte[]> kafkaProducer,
+        IOptions<OutboxRelayOptions> options,
+        ILogger<OutboxMessageRelay> logger,
+        OutboxRelayMetrics outboxRelayMetrics,
+        IMemoryCache memoryCache)
+    {
+        _dbContextFactory = dbContextFactory;
+        _kafkaProducer = kafkaProducer;
+        _outboxRelayOptions = options.Value;
+        _logger = logger;
+        _outboxRelayMetrics = outboxRelayMetrics;
+        _memoryCache = memoryCache;
+    }
+
+    /// <summary>
+    /// Publishes a batch of unpublished outbox messages with an "at least once" delivery guarantee.
+    /// Only messages confirmed as delivered are deleted from the outbox.
+    /// On error, tracks the earliest failed message ID and deletes all messages before it.
+    /// </summary>
+    /// <returns>True if all messages were successfully delivered and confirmed, false otherwise.</returns>
+    public async Task<bool> PublishOutboxMessagesAsync(CancellationToken ct)
+    {
+        var publishedMessagesCount = 0;
+        var publishedMessagesByType = new Dictionary<string, int>();
+        var failedMessagesByType = new Dictionary<string, int>();
+
+        var startTimestamp = Stopwatch.GetTimestamp();
+
+        var maxDeleteId = 0L;
+        var lastSentIdSnapshot = _memoryCache.Get<long>(LastSentIdCacheKey);
+        var outboxDbContext = await _dbContextFactory.CreateDbContextAsync(ct);
+        var outboxMessages = await outboxDbContext.OutboxMessages
+            .Where(m => m.Id > lastSentIdSnapshot)
+            .OrderBy(m => m.Id)
+            .Take(_outboxRelayOptions.BatchSize)
+            .ToListAsync(ct);
+
+        if (outboxMessages.Count == 0)
+        {
+            return true;
+        }
+
+        using var deliveryFailureTracker = new DeliveryFailureTracker(_logger, ct);
+        foreach (var outboxMessage in outboxMessages)
+        {
+            if (deliveryFailureTracker.CancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation(
+                    "Stopping message processing at message {MessageId} due to previous delivery failure",
+                    outboxMessage.Id);
+                break;
+            }
+
+            var messageType = string.Intern(outboxMessage.Type);
+            try
+            {
+                PublishMessage(outboxMessage, deliveryFailureTracker);
+
+                publishedMessagesCount++;
+                publishedMessagesByType[messageType] = publishedMessagesByType.GetValueOrDefault(messageType, 0) + 1;
+                maxDeleteId = outboxMessage.Id;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to call Produce for outbox message {MessageId}", outboxMessage.Id);
+                failedMessagesByType[messageType] = failedMessagesByType.GetValueOrDefault(messageType, 0) + 1;
+                break;
+            }
+        }
+
+        // Flush ensures all buffered messages are sent and delivery reports are received.
+        // DeliveryFailureTracker tracks whether any error happened or not in any delivery report
+        var flushSuccessful = FlushProducer(CancellationToken.None);
+        if (!flushSuccessful)
+        {
+            _logger.LogWarning(
+                "Kafka producer flush failed - short circuiting the execution - leaving messages in the Outbox Table");
+            return false;
+        }
+
+        var earliestFailedId = deliveryFailureTracker.GetEarliestFailedMessageId();
+        if (earliestFailedId.HasValue)
+        {
+            maxDeleteId = earliestFailedId.Value - 1;
+            _logger.LogInformation(
+                "Earliest delivery failure at message ID {FailedId}. Will delete messages up to ID {MaxId}",
+                earliestFailedId.Value, maxDeleteId);
+        }
+
+        _memoryCache.Set(LastSentIdCacheKey, maxDeleteId);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await outboxDbContext.OutboxMessages
+                    .Where(om => om.Id <= maxDeleteId)
+                    .ExecuteDeleteAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete outbox messages up to ID {MaxDeleteId}", maxDeleteId);
+            }
+
+            await outboxDbContext.DisposeAsync();
+        }, CancellationToken.None);
+
+        if (publishedMessagesCount > 0 && !earliestFailedId.HasValue)
+        {
+            var elapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
+            _logger.LogInformation("Published {Count} outbox messages in {ElapsedMMilliseconds}ms",
+                publishedMessagesCount, elapsedTime.TotalMilliseconds);
+
+            _outboxRelayMetrics.RecordProcessingDuration(elapsedTime, publishedMessagesCount);
+        }
+
+        if (publishedMessagesCount > 0 || failedMessagesByType.Count != 0)
+        {
+            foreach (var (messageType, count) in publishedMessagesByType)
+            {
+                _outboxRelayMetrics.RecordMessagesPublished(count, messageType);
+            }
+
+            foreach (var (messageType, count) in failedMessagesByType)
+            {
+                _outboxRelayMetrics.RecordMessagesFailed(count, messageType);
+            }
+        }
+
+        return failedMessagesByType.Count == 0 && !earliestFailedId.HasValue;
+    }
+
+    private void PublishMessage(OutboxMessage outboxMessage, DeliveryFailureTracker deliveryFailureTracker)
+    {
+        var messageHeaders = outboxMessage.DeserializeHeaders();
+        var kafkaMessage = new Message<string?, byte[]>
+        {
+            Key = outboxMessage.KafkaKey,
+            Value = outboxMessage.AvroPayload,
+            Headers = BuildKafkaHeaders(messageHeaders)
+        };
+
+        var topicName = _outboxRelayOptions.TypeTopicMappings.TryGetValue(
+            string.Intern(outboxMessage.Type), out var topic)
+            ? string.Intern(topic)
+            : string.Intern(_outboxRelayOptions.DefaultTopicName);
+
+        var producerActivity = KafkaProducerDiagnostics.StartProduceActivity(topicName, kafkaMessage, messageHeaders);
+
+        // Don't use awaited ProduceAsync unless in http context,
+        // see https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Producer
+        // and https://docs.confluent.io/kafka-clients/dotnet/current/overview.html
+        // The Produce() method is also asynchronous, in that it never blocks.
+        // Message delivery information is made available out-of-band via the (optional) delivery report handler on a background thread
+        // Benchmark here https://concurrentflows.com/kafka-producer-sync-vs-async had 6000x more throughput with sync
+        // Produce over ProduceAsync
+        _kafkaProducer.Produce(
+            topicName,
+            kafkaMessage,
+            deliveryReport =>
+            {
+                // deliveryReport runs on background thread -> thread-safe delivery tracking
+                try
+                {
+                    if (deliveryReport.Error.Code != ErrorCode.NoError)
+                    {
+                        deliveryFailureTracker.RecordFailure(outboxMessage.Id);
+
+                        _logger.LogError(
+                            "Failed to deliver outbox message {MessageId}: {ErrorCode} {ErrorReason}",
+                            outboxMessage.Id, deliveryReport.Error.Code, deliveryReport.Error.Reason);
+
+                        producerActivity?.SetStatus(ActivityStatusCode.Error, deliveryReport.Error.Reason);
+                        producerActivity?.SetTag(OutboxDiagnosticNames.ErrorTag.Type,
+                            deliveryReport.Error.Code.ToString());
+                    }
+                    else if (deliveryReport.Status != PersistenceStatus.Persisted)
+                    {
+                        deliveryFailureTracker.RecordFailure(outboxMessage.Id);
+
+                        _logger.LogError(
+                            "Message {MessageId} with {KafkaKey} was not persisted",
+                            outboxMessage.Id, outboxMessage.KafkaKey);
+
+                        producerActivity?.SetStatus(ActivityStatusCode.Error, "Message not persisted to Kafka");
+                    }
+                    else
+                    {
+                        producerActivity?.SetTag(OutboxDiagnosticNames.Kafka.MessageOffset, deliveryReport.Offset);
+                    }
+                }
+                finally
+                {
+                    producerActivity?.Dispose();
+                }
+            });
+    }
+
+    private static Headers BuildKafkaHeaders(Dictionary<string, string>? messageHeaders)
+    {
+        var kafkaHeaders = new Headers();
+
+        if (messageHeaders == null)
+        {
+            return kafkaHeaders;
+        }
+
+        foreach (var (key, value) in messageHeaders)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                kafkaHeaders.Add(key, Encoding.UTF8.GetBytes(value));
+            }
+        }
+
+        return kafkaHeaders;
+    }
+
+    /// <summary>
+    /// Flushes pending messages to Kafka - wait until all outstanding produce requests and delivery report callbacks are completed.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if flush completed successfully, false if canceled or error occurred.</returns>
+    public bool FlushProducer(CancellationToken ct = default)
+    {
+        var flushTimeout = TimeSpan.FromMilliseconds(_outboxRelayOptions.FlushTimeoutMs);
+        _logger.LogDebug("Flushing Kafka producer with timeout {TimeoutMs}ms", flushTimeout.TotalMilliseconds);
+
+        try
+        {
+            using var flushCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            flushCts.CancelAfter(flushTimeout);
+            _kafkaProducer.Flush(flushCts.Token);
+
+            _logger.LogDebug("Kafka producer flush completed successfully");
+            return true;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogWarning(ex,
+                "Kafka producer flush was canceled - likely due to timeout or external cancellation");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred during Kafka producer flush");
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Disposing Kafka producer");
+
+            var flushSuccessful = FlushProducer();
+            if (!flushSuccessful)
+            {
+                _logger.LogWarning("Kafka producer flush failed");
+            }
+
+            _kafkaProducer.Dispose();
+
+            _logger.LogInformation("Kafka producer disposed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during disposal of Kafka producer");
+        }
+        finally
+        {
+            _disposed = true;
+        }
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxRelayWorker.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxRelayWorker.cs
@@ -1,0 +1,94 @@
+using DotNetAtlas.OutboxRelay.WorkerService.Observability.Metrics;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Microsoft.Extensions.Options;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay;
+
+/// <summary>
+/// Background service that periodically polls the outbox table and publishes messages to Kafka.
+/// Implements graceful shutdown with configurable flush and total shutdown timeouts.
+/// </summary>
+public sealed class OutboxRelayWorker : BackgroundService
+{
+    private readonly ILogger<OutboxRelayWorker> _logger;
+    private readonly OutboxRelayOptions _outboxRelayOptions;
+    private readonly OutboxRelayMetrics _outboxRelayMetrics;
+    private readonly OutboxMessageRelay _outboxMessageRelay;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OutboxRelayWorker"/> class.
+    /// </summary>
+    /// <param name="options">Configuration options for polling interval, batch size, and topic mappings.</param>
+    /// <param name="logger">Logger for recording worker events and errors.</param>
+    /// <param name="outboxRelayMetrics">Metrics collector for tracking the last successful execution.</param>
+    /// <param name="outboxMessageRelay">Outbox Message Relay for publishing outbox messages.</param>
+    public OutboxRelayWorker(
+        IOptions<OutboxRelayOptions> options,
+        ILogger<OutboxRelayWorker> logger,
+        OutboxRelayMetrics outboxRelayMetrics,
+        OutboxMessageRelay outboxMessageRelay)
+    {
+        _outboxRelayOptions = options.Value;
+        _logger = logger;
+        _outboxRelayMetrics = outboxRelayMetrics;
+        _outboxMessageRelay = outboxMessageRelay;
+    }
+
+    /// <summary>
+    /// Executes the outbox relay polling loop until cancellation is requested.
+    /// </summary>
+    /// <param name="stoppingToken">Token to signal graceful shutdown.</param>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var typeMappingsInfo = _outboxRelayOptions.TypeTopicMappings.Count > 0
+            ? $", type mappings: {string.Join(", ", _outboxRelayOptions.TypeTopicMappings.Select(kvp => $"{kvp.Key}→{kvp.Value}"))}"
+            : ", no type mappings configured";
+
+        _logger.LogInformation(
+            "OutboxRelay started. Config: polling={PollingMs}ms, batch={BatchSize}, " +
+            "flushTimeout={FlushMs}ms, shutdownTimeout={ShutdownMs}ms{TypeMappingInfo}",
+            _outboxRelayOptions.PollingIntervalMs, _outboxRelayOptions.BatchSize,
+            _outboxRelayOptions.FlushTimeoutMs, _outboxRelayOptions.ShutdownTimeoutMs, typeMappingsInfo);
+
+        using var periodicTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(_outboxRelayOptions.PollingIntervalMs));
+
+        while (await periodicTimer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var wasSuccessful = await _outboxMessageRelay.PublishOutboxMessagesAsync(stoppingToken);
+                if (wasSuccessful)
+                {
+                    _outboxRelayMetrics.RecordSuccessfulExecution();
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Shutdown requested during message processing");
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing outbox batch");
+            }
+        }
+
+        _logger.LogInformation("OutboxRelay polling stopped, beginning shutdown sequence");
+    }
+
+    /// <summary>
+    /// Graceful shutdown - flushes pending messages to ensure no data loss during shutdown.
+    /// </summary>
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("OutboxRelay graceful shutdown initiated");
+
+        var flushSuccessful = _outboxMessageRelay.FlushProducer(cancellationToken);
+        if (!flushSuccessful)
+        {
+            _logger.LogWarning("Kafka producer flush failed during graceful shutdown");
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/packages.lock.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/packages.lock.json
@@ -1,0 +1,51 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ=="
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "MnPx3NJT7pLBfOgIVs1/IXL8n5sEErhaJu14TQujaXTMwzv9I3v+nzPqUrUuEunaHeeH10n/3oZBn/Xg4trP0g=="
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "kPhYbH1DmcT1GQUGPQqMGEaQKAGVA31tStPy/ESXPeC8xCVqq7KZg1EKq6XoV4MSgPJ4X/XzZyKHo6Bk8FVbdg=="
+      }
+    },
+    "net10.0/win-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "pGlnnJrQ4s3pjbvaTlC1MeZ+x18t2iYn25Jz+nzzgp0BCndbSxbxHzFL2IzV55bbeKecJszF8/8RHFKwVjRKpQ==",
+        "dependencies": {
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "+oUu2CGnaaWBwFYC3HWXeOeNqBKiE7vdoofgEFrwZXT2m1d03T+DeUSiub5K//Bt9JEZD3/7BfE62k+a5ZRwwA=="
+      }
+    }
+  }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Program.cs
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Program.cs
@@ -1,0 +1,54 @@
+using DotNetAtlas.OutboxRelay.WorkerService.Common;
+using DotNetAtlas.OutboxRelay.WorkerService.Common.Extensions;
+using DotNetAtlas.OutboxRelay.WorkerService.OutboxRelay.Config;
+using Serilog;
+
+namespace DotNetAtlas.OutboxRelay.WorkerService;
+
+#pragma warning disable CA1052
+public class Program
+#pragma warning restore CA1052
+{
+    public static async Task Main(string[] args)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .CreateBootstrapLogger();
+
+        try
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            var isClusterEnvironment = builder.Environment.IsInCluster();
+
+            builder.Configuration.AddEnvironmentVariables();
+
+            builder.UseSerilogInternal(isClusterEnvironment);
+            builder.Services.AddOpenTelemetryInternal(isClusterEnvironment, builder.Configuration);
+            builder.Services.AddHealthChecksInternal(builder.Configuration);
+            builder.Services.AddDatabase(builder.Configuration);
+            builder.Services.AddMemoryCache();
+            builder.AddOutboxRelayWorker();
+
+            var app = builder.Build();
+
+            app.MapHealthChecksInternal();
+            app.UseHealthChecksPrometheusExporterInternal();
+
+            await app.RunAsync();
+        }
+        catch (HostAbortedException)
+        {
+            Log.Information("Host aborted, shutting down gracefully");
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Host terminated unexpectedly");
+            throw;
+        }
+        finally
+        {
+            await Log.CloseAndFlushAsync();
+        }
+    }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/Properties/launchSettings.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DotNetAtlas.OutboxRelay.WorkerService.Local": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Local"
+      },
+      "applicationUrl": "https://localhost:65409;http://localhost:65410"
+    }
+  }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.Local.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.Local.json
@@ -1,0 +1,22 @@
+{
+  // Cross-Cutting Concerns
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "Microsoft.EntityFrameworkCore": "Information",
+        "System": "Information"
+      }
+    }
+  },
+  // Communication & Messaging
+  "Kafka": {
+    "AvroSerializer": {
+      "AutoRegisterSchemas": true
+    }
+  },
+  "OutboxRelay": {
+    "PollingIntervalMs": 500
+  }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.json
@@ -1,0 +1,75 @@
+{
+  // Cross-Cutting Concerns
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft": "Warning"
+      }
+    }
+  },
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+  "AllowedHosts": "*",
+  // Infrastructure layer
+  // Data
+  "ConnectionStrings": {
+    "Outbox": "Data Source=127.0.0.1,12345;Initial Catalog=Weather;Persist Security Info=False;User ID=sa;Password=breK3k3$;Encrypt=True;TrustServerCertificate=True"
+  },
+  "EfCore": {
+    "DbContextPoolSize": 10,
+    "RetryMaxCount": 6,
+    "RetryMaxDelaySeconds": 30,
+    "EnableDetailedErrors": true
+  },
+  // Communication & Messaging
+  "KafkaProducer": {
+    "ClientId": "outbox-relay-worker",
+    "BootstrapServers": "localhost:9094",
+    "Acks": "All",
+    "EnableIdempotence": true,
+    "MaxInFlight": 5,
+    "CompressionType": "None",
+    "LingerMs": 5,
+    "BatchSize": 16384,
+    "MaxMessageBytes": 1048576,
+    "MessageTimeoutMs": 300000,
+    "RequestTimeoutMs": 30000,
+    "MessageSendMaxRetries": 10,
+    "RetryBackoffMs": 100
+  },
+  // Background Processing
+  "OutboxRelay": {
+    "PollingIntervalMs": 1000,
+    "BatchSize": 1000,
+    "DefaultTopicName": "weather.feedback.events",
+    "SchemaName": "weather",
+    "TableName": "OutboxMessages",
+    "FlushTimeoutMs": 30000,
+    "ShutdownTimeoutMs": 60000,
+    "TypeTopicMappings": {
+      "FeedbackCreatedEvent": "weather.feedback.events",
+      "FeedbackChangedEvent": "weather.feedback.events"
+    }
+  },
+  // Health Monitoring
+  "OutboxRelayHealthCheck": {
+    "DegradedThresholdMultiplier": 1.5,
+    "UnhealthyThresholdMultiplier": 3.0,
+    "MinimumDegradedThreshold": "00:00:30",
+    "MinimumUnhealthyThreshold": "00:01:00",
+    "StartupGracePeriod": "00:02:00"
+  },
+  "HealthChecks": {
+    "SelfTimeout": "00:00:02",
+    "OutboxRelayExecutionTimeout": "00:00:05",
+    "KafkaTimeout": "00:00:03",
+    "OutboxLag": {
+      "WarningThreshold": 100,
+      "ErrorThreshold": 1000
+    }
+  },
+  "OutboxMetricsCollector": {
+    "ReportIntervalSeconds": 5
+  }
+}

--- a/platform/DotNetAtlas.OutboxRelay.WorkerService/packages.lock.json
+++ b/platform/DotNetAtlas.OutboxRelay.WorkerService/packages.lock.json
@@ -1,0 +1,870 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AspNetCore.HealthChecks.Kafka": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "RZur8bOLjg/odBq495aT2x606kaO8j/nq/FFvc4CKtRGR8Seh7PGlbVKsGR7cjwUVFkorxNCdlJ8JFvdzXP9jQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.3.0"
+        }
+      },
+      "AspNetCore.HealthChecks.Prometheus.Metrics": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "0xeg62XzCl7VqfsPLw3Tt0gKCGqAa/gW5iPiLaLHRqVt21vGbAgn9RLnSE/AoLolq23FdTjwgfKIJc/o3EQbKw==",
+        "dependencies": {
+          "prometheus-net": "8.1.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Core": {
+        "type": "Direct",
+        "requested": "[17.14.28, )",
+        "resolved": "17.14.28",
+        "contentHash": "jk3O0tXp9QWPXhLJ7Pl8wm/eGtGgA1++vwHGWEmnwMU6eP//ghtcCUpQh9CQMwEKGDnH0aJf285V1s8yiSlKfQ==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "17.14.28",
+          "Microsoft.Build.Utilities.Core": "17.14.28",
+          "Microsoft.NET.StringTools": "17.14.28",
+          "System.CodeDom": "9.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.0",
+          "System.Formats.Nrbf": "9.0.0",
+          "System.Resources.Extensions": "9.0.0",
+          "System.Security.Cryptography.Pkcs": "9.0.0",
+          "System.Security.Cryptography.ProtectedData": "9.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "1Rs5ljF2F7Zr43kLhyuGuRL/jGneL+USb/tbLrOzTjpLnu8kIjpOBPX6KaSAC5RN6pOyciQ+KeI7fuRSiH8c6w==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.14.8",
+          "Microsoft.Build.Locator": "1.9.1",
+          "Microsoft.Build.Tasks.Core": "17.14.8",
+          "Microsoft.Build.Utilities.Core": "17.14.8",
+          "Microsoft.CodeAnalysis.CSharp": "4.14.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "4.14.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "4.14.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0-rc.1.25451.107",
+          "Microsoft.Extensions.DependencyModel": "10.0.0-rc.1.25451.107",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "2VGsIkjslD/3xaLaI6ggNvhO4uOi03nCdruo4l7U8S8+Y8tDqCIbp3zIDFgGcOjVtWcrEUTV0qTBfR02Y0+EFA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.1",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "RYYIUkCwG2Rd0/MEBX/CWblt5ZP7u0TW9y5Fmq9gRBKauW7R10j0x6PTKJGABffnL3jmDNxBdy4B5T/qH5s60w==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "7LzQSPhz5pNaL4xZgT3wkZODA1NLrEq3bet8KDHgtaJ9q+VNP7wmiZky8gQfMkB4FXuI/pevT8ZurL4p5997WA==",
+        "dependencies": {
+          "OpenTelemetry": "1.12.0"
+        }
+      },
+      "OpenTelemetry.Exporter.Prometheus.AspNetCore": {
+        "type": "Direct",
+        "requested": "[1.12.0-beta.1, )",
+        "resolved": "1.12.0-beta.1",
+        "contentHash": "S34hBEn/g5TuCBhHFqR+efyQ8YIJ6BOjg7L/zPGyGAGBbQX4kY/pfiMA9BPniHXwSJqaEnbgddB6OfMEVTniug==",
+        "dependencies": {
+          "OpenTelemetry": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "6/8O6rsJRwslg5/Fm3bscBelw4Yh9T9CN24p7cAsuEFkrmmeSO9gkYUCK02Qi+CmPM2KHYTLjKi0lJaCsDMWQA==",
+        "dependencies": {
+          "OpenTelemetry": "1.12.0"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "r+Mzggd2P4N0Y34QIO6kakVPBOKFYSHnLkTrXXM+r37ABp+iaUvVUe+u/uxszsi5f7P5mrG0uYYaJ1QGHvzo3A==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "0rW+MbHgUQAdbvBtRxPYoQBosbNdWegL7cYkRlxq+KQ/VFyU8itt4pWTccmu1/FWmTgqJyT3LaujyDZoRrm8Yg==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Process": {
+        "type": "Direct",
+        "requested": "[1.12.0-beta.1, )",
+        "resolved": "1.12.0-beta.1",
+        "contentHash": "GrjqeNzH94WOpUpKO7xO13NjBujk0wxvxzGBFuvU+kIAzMB22a4PzOGPrvQivx27RIKaFH+psQP6dTPUmv/8sA==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "xmd0TAm2x+T3ztdf5BolIwLPh+Uy6osaBeIQtCXv611PN7h/Pnhsjg5lU2hkAWj7M7ns74U5wtVpS8DXmJ+94w==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Resources.Container": {
+        "type": "Direct",
+        "requested": "[1.12.0-beta.1, )",
+        "resolved": "1.12.0-beta.1",
+        "contentHash": "a/R9ru7FWV9UhlySwX8CfTCroYNSDint0ZaIGNFnXhTBgXbbWEm31/YCGjFtqXQxqB+K11vt1d9rumdqK5klYA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.12.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Resources.Host": {
+        "type": "Direct",
+        "requested": "[1.12.0-beta.1, )",
+        "resolved": "1.12.0-beta.1",
+        "contentHash": "CXuz9kyuy8VIAkMy/vQHIXFFDsGXnOiBrfBLbDJSOa6XeIEKn+LEZ+lAu8QSN1CT7t0CS8VIswzS5OEpj4fKEg==",
+        "dependencies": {
+          "OpenTelemetry": "[1.12.0, 2.0.0)"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "JslDajPlBsn3Pww1554flJFTqROvK9zz9jONNQgn0D8Lx2Trw8L0A8/n6zEQK1DAZWXrJwiVLw8cnTR3YFuYsg==",
+        "dependencies": {
+          "Serilog": "4.2.0",
+          "Serilog.Extensions.Hosting": "9.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "9.0.0",
+          "Serilog.Sinks.Console": "6.0.0",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "6.0.0"
+        }
+      },
+      "Serilog.Expressions": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "fQGWqVMClCP2yEyTXPIinSr5c+CBGUvBybPxjAGcf7ctDhadFhrQw03Mv8rJ07/wR5PDfFjewf2LimvXCDzpbA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.OpenTelemetry": {
+        "type": "Direct",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "PzMCyE5G19tjr5IZEi5qg+4UU5QrxBEoBEMu/hhYybTrGKXqUDiSGWKZNUDBgelaVKqLADlsmlJVyKce5SyPrg==",
+        "dependencies": {
+          "Google.Protobuf": "3.30.1",
+          "Grpc.Net.Client": "2.70.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.47.1",
+        "contentHash": "oPcncSsDHuxB8SC522z47xbp2+ttkcKv2YZ90KXhRKN0YQd2+7l1UURT9EBzUNEXtkLZUOAB5xbByMTrYRh3yA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.5.1",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.14.2",
+        "contentHash": "YhNMwOTwT+I2wIcJKSdP0ADyB2aK+JaYWZxO8LSRDm5w77LFr0ykR9xmt2ZV5T1gaI7xU6iNFIh/yW1dAlpddQ==",
+        "dependencies": {
+          "Azure.Core": "1.46.1",
+          "Microsoft.Identity.Client": "4.73.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.73.1"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "Udblxd6/nax84IxplqU1SxcbH+OTeVGUaQ3Mi/9xXUD63D3S2bZGHX5Jca8V1QMnt7IX4sCd/wKYAvsT3UjEaQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.6.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.30.1",
+        "contentHash": "HeWXDQBabQn/sCGicbeLJ0HMunknfC4FdLrOQOsaMJHcpqx3HVIpyyJqTrqJlWnza870twhOb+rBcaTiC/TlNA=="
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "66UotvWcSIq41oiQhLWcQACyKPM4umxXNiht5DQTLZJfNwEswWOcS7Z0xIEHyNIBE7ZpjotH22bEjTkvhPxmVw=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.70.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "rBdEUMyCwa+iB8mqC6JKyPbj3SBHHkReJj/yy/XKJI63GcG6w9DJMMGTVcYHqq4Ci2W4m0HT4jt2pFfFscar8g==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.70.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "RcpH/eqmfp08RmfeQdHeJEz0OaAcYWJo8EqQiU4ohDrBygIXbWhCTksUFkhYGqap/5Ycm+HC9RVSlwetFo9SlA=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "YgZYAWzyNuPVtPq6WNm0bqOWNjYaWgl5mBWTGZyNoXitYBUYSp6iUB9AwK0V1mo793qRJUXz2t6UZrWITZSvuQ=="
+      },
+      "Microsoft.Build": {
+        "type": "Transitive",
+        "resolved": "17.7.2",
+        "contentHash": "AmWnumxsMiRycFfE3kq/XnFFTAoPpCWl3UuiKQWCa5Z0+hBKVoiydzS2iXJGd3x+jry+qaTR9GzoezjV9NFT5A==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "17.7.2",
+          "Microsoft.NET.StringTools": "17.7.2",
+          "System.Configuration.ConfigurationManager": "7.0.0",
+          "System.Reflection.MetadataLoadContext": "7.0.0",
+          "System.Security.Permissions": "7.0.0"
+        }
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "17.14.28",
+        "contentHash": "wRcyTzGV0LRAtFdrddtioh59Ky4/zbvyraP0cQkDzRSRkhgAQb0K88D/JNC6VHLIXanRi3mtV1jU0uQkBwmiVg=="
+      },
+      "Microsoft.Build.Locator": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "UTO1acAAxYkpI8lU9ff5D9kn4p85bFwph28Y3QPVM9qy5HKQy3kpB6gWcuVGtlSPtvfzfC67CMDHO/JDys2gNQ=="
+      },
+      "Microsoft.Build.Utilities.Core": {
+        "type": "Transitive",
+        "resolved": "17.14.28",
+        "contentHash": "rhSdPo8QfLXXWM+rY0x0z1G4KK4ZhMoIbHROyDj8MUBFab9nvHR0NaMnjzOgXldhmD2zi2ir8d6xCatNzlhF5g==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "17.14.28",
+          "Microsoft.NET.StringTools": "17.14.28",
+          "System.Configuration.ConfigurationManager": "9.0.0",
+          "System.Security.Cryptography.ProtectedData": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "PC3tuwZYnC+idaPuoC/AZpEdwrtX7qFpmnrfQkgobGIWiYmGi5MCRtl5mx6QrfMGQpK78X2lfIEoZDLg/qnuHg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "568a6wcTivauIhbeWcCwfWwIn7UV7MeHEBvFB2uzGIpM2OhJ4eM/FZ8KS0yhPoNxnSpjGzz7x7CIjTxhslojQA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[4.14.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "QkgCEM4qJo6gdtblXtNgHqtykS61fxW+820hx5JN6n9DD4mQtqNB+6fPeJ3GQWg6jkkGz6oG9yZq7H3Gf0zwYw==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[4.14.0]",
+          "Microsoft.CodeAnalysis.Common": "[4.14.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.14.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "wNVK9JrqjqDC/WgBUFV6henDfrW87NPfo98nzah/+M/G1D6sBOPtXwqce3UQNn+6AjTnmkHYN1WV9XmTlPemTw==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[4.14.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "YU7Sguzm1Cuhi2U6S0DRKcVpqAdBd2QmatpyE0KqYMJogJ9E27KHOWGUzAOjsyjAM7sNaUk+a8VPz24knDseFw==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build": "17.7.2",
+          "Microsoft.Build.Framework": "17.7.2",
+          "Microsoft.Build.Tasks.Core": "17.7.2",
+          "Microsoft.Build.Utilities.Core": "17.7.2",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.14.0]",
+          "Newtonsoft.Json": "13.0.3",
+          "System.CodeDom": "7.0.0",
+          "System.Composition": "9.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.0",
+          "System.Resources.Extensions": "9.0.0",
+          "System.Security.Cryptography.Pkcs": "7.0.2",
+          "System.Security.Cryptography.ProtectedData": "9.0.0",
+          "System.Security.Permissions": "9.0.0",
+          "System.Windows.Extensions": "9.0.0"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "syGQmIUPAYYHAHyTD8FCkTNThpQWvoA7crnIQRMfp8dyB5A2cWU3fQexlRTFkVmV7S0TjVmthi0LJEFVjHo8AQ==",
+        "dependencies": {
+          "Azure.Core": "1.47.1",
+          "Azure.Identity": "1.14.2",
+          "Microsoft.Bcl.Cryptography": "9.0.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.4",
+          "System.Security.Cryptography.Pkcs": "9.0.4"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "447K5zsovuadqFj8k9nOXiD4bI+iCwteVYp2BUys9CFhnOi42VVDzXzTzrMK1bLhfyawk6X3ZP1sKD0lodTToA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "9iNDa8n9neV+SnjMx8FnaOTwpuyuQg/LMiOSEiJbCSHsb66qLbOCJ3HtMm9nh6TXabYdq3ysUC4y2StYB7+6hA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "1ncKiILhT+X6vZtuL9en37ARjD6k/EtSXdwZl1doItDu1n8Xzz2tRX2l9bTdLZV6R4pZp3wm2Krue6+mBtWxdA=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.73.1",
+        "contentHash": "NnDLS8QwYqO5ZZecL2oioi1LUqjh5Ewk4bMLzbgiXJbQmZhDLtKwLxL3DpGMlQAJ2G4KgEnvGPKa+OOgffeJbw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.73.1",
+        "contentHash": "xDztAiV2F0wI0W8FLKv5cbaBefyLD6JVaAsvgSN7bjWNCzGYzHbcOEIP5s4TJXUpQzMfUyBsFl1mC6Zmgpz0PQ==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.73.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "S7sHg6gLg7oFqNGLwN1qSbJDI+QcRRj8SuJ1jHyCmKSipnF6ZQL+tFV2NzVfGj/xmGT9TykQdQiBN+p5Idl4TA=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "3Izi75UCUssvo8LPx3OVnEeZay58qaFicrtSnbtUt7q8qQi0gy46gh4V8VUTkMVMKXV6VMyjBVmeNNgeCUJuIw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "BZNgSq/o8gsKExdYoBKPR65fdsxW0cTF8PsdqB8y011AGUJJW300S/ZIsEUD0+sOmGc003Gwv3FYbjrVjvsLNQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.7.1",
+          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "fQ0VVCba75lknUHGldi3iTKAYUQqbzp1Un8+d9cm9nON0Gs8NAkXddNg8iaUB0qi/ybtAmNWizTR4avdkCJ9pQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.7.1"
+        }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.14.28",
+        "contentHash": "DMIeWDlxe0Wz0DIhJZ2FMoGQAN2yrGZOi5jjFhRYHWR5ONd0CS6IpAHlRnA7uA/5BF+BADvgsETxW2XrPiFc1A=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.12.0",
+        "contentHash": "aIEu2O3xFOdwIVH0AJsIHPIMH1YuX18nzu7BHyaDNQ6NWSk4Zyrs9Pp6y8SATuSbvdtmvue4mj/QZ3838srbwA==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.12.0"
+        }
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.12.0",
+        "contentHash": "t6Vk1143BfiisCWYbRcyzkAuN6Aq5RkYtfOSMoqCIRMvtN9p1e1xzc0nWQ+fccNGOVgHn3aMK5xFn2+iWMcr8A==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.12.0"
+        }
+      },
+      "prometheus-net": {
+        "type": "Transitive",
+        "resolved": "8.1.0",
+        "contentHash": "4prJfXFYmCPtuedjSjvtsI9BGjsH6hXrqz/yAOx07osiVwzRVyLP7Os+5rFJ5g2PLOoO3149RbEyp2/b223/CQ=="
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "gmoWVOvKgbME8TYR+gwMf7osROiWAURterc6Rt2dQyX7wtjZYpqFiA/pY6ztjGQKKV62GGCyOcmtP1UKMHgSmA=="
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lxjg89Y8gJMmFxVkbZ+qDgjl+T4yC5F7WSLTvA+5q0R04tfKVLRL/EHpYoJ/MEQd2EeCKDuylBIVnAYMotmh2A==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.5.1",
+        "contentHash": "k2jKSO0X45IqhVOT9iQB4xralNN9foRQsRvXBTyRpAVxyzCJlG895T9qYrQWbcJ6OQXxOouJQ37x5nZH5XKK+A==",
+        "dependencies": {
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "oTE5IfuMoET8yaZP/vdvy9xO47guAv/rOhe4DODuFBN3ySprcQOlXqO3j+e/H/YpKKR5sglrxRaZ2HYOhNJrqA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "dvjqKp+2LpGid6phzrdrS/2mmEPxFl3jE1+L7614q4ZChKbLJCpHXg6sBILlCCED1t//EE+un/UdAetzIMpqnw==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "9.0.4"
+        }
+      },
+      "System.Formats.Nrbf": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "F/6tNE+ckmdFeSQAyQo26bQOqfPFKEfZcuqnp4kBE6/7jP26diP+QTHCJJ6vpEfaY6bLy+hBLiIQUSxSmNwLkA=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "rQkO1YbAjLwnDJSMpRhRtrc6XwIcEOcUvoEcge+evurpzSZM3UNK+MZfD3sKyTlYsvknZ6eJjSBfnmXqwOsT9Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
+      },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "z9PvtMJra5hK8n+g0wmPtaG7HQRZpTmIPRw5Z0LEemlcdQMHuTD5D7OAY/fZuuz1L9db++QOcDF0gJTLpbMtZQ=="
+      },
+      "System.Resources.Extensions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "tvhuT1D2OwPROdL1kRWtaTJliQo0WdyhvwDpd8RM997G7m3Hya5nhbYhNTS75x6Vu+ypSOgL5qxDCn8IROtCxw==",
+        "dependencies": {
+          "System.Formats.Nrbf": "9.0.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "cUFTcMlz/Qw9s90b2wnWSCvHdjv51Bau9FQqhsr4TlwSe1OX+7SoXUqphis5G74MLOvMOCghxPPlEqOdCrVVGA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "o94k2RKuAce3GeDMlUvIXlhVa1kWpJw95E6C9LwW0KlG0nj5+SgCiIxJ2Eroqb9sLtG1mEMbFttZIBZ13EJPvQ=="
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "H2VFD4SFVxieywNxn9/epb63/IOcPPfA0WOtfkljzNfu7GCcHIBQNuwP6zGCEIi7Ci/oj8aLPUNK9sYImMFf4Q==",
+        "dependencies": {
+          "System.Windows.Extensions": "9.0.0"
+        }
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "U9msthvnH2Fsw7xwAvIhNHOdnIjOQTwOc8Vd0oGOsiRcGMGoBFlUD6qtYawRUoQdKH9ysxesZ9juFElt1Jw/7A=="
+      },
+      "dotnetatlas.outbox.core": {
+        "type": "Project",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.12.0, )"
+        }
+      },
+      "dotnetatlas.outbox.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.0, )",
+          "Confluent.Kafka": "[2.6.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.6.1, )",
+          "DotNetAtlas.Outbox.Core": "[1.0.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.0-rc.1.25451.107, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.0-rc.1.25451.107, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "gFFnQ8j91zdbs5QvGo79139WnLpQB4rPbDx2Bnr664uBMSGhh422QsHd89Vv7WyT0+eT7qPL+6rZlnyor3aATw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.1, )",
+        "resolved": "2.6.1",
+        "contentHash": "DCap4xzbUzItoFVBCmBbng6q4XbaxfqLgR/b56b67L9S0iUTIwrSAvk3MPegyQNn56+1C/m3ytwy1YU+nAuqDA==",
+        "dependencies": {
+          "librdkafka.redist": "2.6.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.1, )",
+        "resolved": "2.6.1",
+        "contentHash": "rwMyVRgSZyMLibc7GwaEoE5Z/NucWExg5QiYgk9u2/4lsNzwjLLgV+cMc5hyOGzePehd22HdBUdUq4/0sNAYhg==",
+        "dependencies": {
+          "Apache.Avro": "1.12.0",
+          "Confluent.Kafka": "2.6.1",
+          "Confluent.SchemaRegistry": "2.6.1"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "tE6qyRUFoVI+5HmJy5oGyPRvv4SfJH/jpDb94b40MxnNQhRtkIDQUuinWfMd8B2YAgXtVXANBNWjQ3ojsW/1Wg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.0-rc.1.25451.107",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-rc.1.25451.107, )",
+        "resolved": "10.0.0-rc.1.25451.107",
+        "contentHash": "LQhyp5JclWH3OvCW29NNgc1ZSPZ6wMotRPzCO69wOMCf+WVXa8GpiILF2qvbx9ax0dSjz36UuG2I5ZQ5so+e7Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.0-rc.1.25451.107"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "Xt0qldi+iE2szGrM3jAqzEMEJd48YBtqI6mge0+ArXTZg3aTpRmyhL6CKKl3bLioaFSSVbBpEbPin8u6Z46Yrw=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "u2TRxuxbjvTAldQn7uaAwePkWxTHIqlgjelekBtilAGL5sYyF3+65NWctN4UrwwGLsDC7c3Vz3HnOlu+PcoxXg==",
+        "dependencies": {
+          "Serilog": "4.2.0",
+          "Serilog.Extensions.Logging": "9.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.2, )",
+        "resolved": "9.0.0",
+        "contentHash": "NwSSYqPJeKNzl5AuXVHpGbr6PkZJFlNa14CdIebVjK3k/76kYj/mz5kiTRNVSsSaxM8kAIa1kpy/qyT9E4npRQ==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "4/Et4Cqwa+F88l5SeFeNZ4c4Z6dEAIKbu3MaQb2Zz9F/g27T5a3wvfMcmCOaAiACjfUb4A6wrlTVfyYUZk3RRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "9.0.0",
+          "Serilog": "4.2.0"
+        }
+      }
+    },
+    "net10.0/linux-x64": {
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "RcpH/eqmfp08RmfeQdHeJEz0OaAcYWJo8EqQiU4ohDrBygIXbWhCTksUFkhYGqap/5Ycm+HC9RVSlwetFo9SlA=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "syGQmIUPAYYHAHyTD8FCkTNThpQWvoA7crnIQRMfp8dyB5A2cWU3fQexlRTFkVmV7S0TjVmthi0LJEFVjHo8AQ==",
+        "dependencies": {
+          "Azure.Core": "1.47.1",
+          "Azure.Identity": "1.14.2",
+          "Microsoft.Bcl.Cryptography": "9.0.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.4",
+          "System.Security.Cryptography.Pkcs": "9.0.4"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "cUFTcMlz/Qw9s90b2wnWSCvHdjv51Bau9FQqhsr4TlwSe1OX+7SoXUqphis5G74MLOvMOCghxPPlEqOdCrVVGA=="
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "U9msthvnH2Fsw7xwAvIhNHOdnIjOQTwOc8Vd0oGOsiRcGMGoBFlUD6qtYawRUoQdKH9ysxesZ9juFElt1Jw/7A=="
+      }
+    },
+    "net10.0/win-x64": {
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "RcpH/eqmfp08RmfeQdHeJEz0OaAcYWJo8EqQiU4ohDrBygIXbWhCTksUFkhYGqap/5Ycm+HC9RVSlwetFo9SlA=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "syGQmIUPAYYHAHyTD8FCkTNThpQWvoA7crnIQRMfp8dyB5A2cWU3fQexlRTFkVmV7S0TjVmthi0LJEFVjHo8AQ==",
+        "dependencies": {
+          "Azure.Core": "1.47.1",
+          "Azure.Identity": "1.14.2",
+          "Microsoft.Bcl.Cryptography": "9.0.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.4",
+          "System.Security.Cryptography.Pkcs": "9.0.4"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "cUFTcMlz/Qw9s90b2wnWSCvHdjv51Bau9FQqhsr4TlwSe1OX+7SoXUqphis5G74MLOvMOCghxPPlEqOdCrVVGA=="
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "U9msthvnH2Fsw7xwAvIhNHOdnIjOQTwOc8Vd0oGOsiRcGMGoBFlUD6qtYawRUoQdKH9ysxesZ9juFElt1Jw/7A=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
- OutboxMessageRelay for batch processing and Kafka publishing with delivery guarantees
- Configurable polling intervals, batch sizes, and topic mappings
- OpenTelemetry instrumentation for distributed tracing and metrics
- Health checks monitoring service execution and dependencies
- Prometheus metrics for outbox lag, processing duration, and message counts
- Serilog logging with OpenTelemetry integration
- Entity Framework Core integration with SQL Server
- Docker containerization with multi-stage builds
- Comprehensive configuration validation and options pattern


___

### **PR Type**
Enhancement


___

### **Description**
- Core outbox message relay service with batch processing and Kafka publishing capabilities

- OpenTelemetry instrumentation for distributed tracing and metrics collection with semantic conventions

- Comprehensive health checks for database, Kafka, and relay service execution monitoring

- Prometheus metrics for outbox lag, processing duration, and message counts with dimensional analysis

- Entity Framework Core integration with SQL Server and connection pooling with retry policies

- Serilog structured logging with OpenTelemetry and console sinks

- Multi-stage Docker containerization with performance optimizations (GC server, tiered PGO)

- Configurable polling intervals, batch sizes, topic mappings, and health check thresholds

- Dependency injection and configuration validation using options pattern

- Development and local environment-specific configurations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DB["SQL Server<br/>Outbox Table"]
  OMR["OutboxMessageRelay<br/>Batch Processor"]
  KP["Kafka Producer<br/>with Tracing"]
  KAFKA["Kafka<br/>Topics"]
  METRICS["Prometheus<br/>Metrics"]
  HC["Health Checks<br/>Readiness/Liveness"]
  OTEL["OpenTelemetry<br/>Exporter"]
  
  DB -- "Poll Messages" --> OMR
  OMR -- "Publish" --> KP
  KP -- "Send" --> KAFKA
  OMR -- "Record" --> METRICS
  OMR -- "Report Status" --> HC
  METRICS -- "Export" --> OTEL
  HC -- "Export" --> OTEL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>OutboxMessageRelay.cs</strong><dd><code>Outbox message relay with Kafka publishing and tracing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxMessageRelay.cs

<ul><li>Core message relay service that polls outbox table and publishes <br>messages to Kafka<br> <li> Implements batch processing with configurable batch sizes and polling <br>intervals<br> <li> Tracks last sent message ID in memory cache to avoid reprocessing<br> <li> Integrates OpenTelemetry tracing for Kafka producer operations with <br>delivery callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-8ad4ebde6f1a2d1a937d473387660e67043f6199181f8a0a9b6d44461861947b">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayMetrics.cs</strong><dd><code>Prometheus metrics instrumentation for outbox relay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetrics.cs

<ul><li>Custom metrics collection using System.Diagnostics.Metrics for outbox <br>monitoring<br> <li> Counters for published and failed messages with message type <br>dimensions<br> <li> Observable gauges for outbox size, head/tail lag, and time since last <br>execution<br> <li> Histogram for batch processing duration with processed count <br>categorization</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-30b58fb98ea5cd8af102b2763fa4bb0d105eec7be9b6404d04bae319fe6bfcba">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxMetricsCollector.cs</strong><dd><code>Background metrics collection for outbox monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollector.cs

<ul><li>Background service that periodically collects outbox metrics<br> <li> Calculates head and tail lag based on message creation timestamps<br> <li> Updates pending message count and reports metrics at configurable <br>intervals<br> <li> Uses TimeProvider for testable time operations</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-d7a101d525c10f5e64672055f25bd0ea689e1deb95ba5bf13f5b719dae3d79f1">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayHealthCheck.cs</strong><dd><code>Health check for outbox relay execution monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheck.cs

<ul><li>Health check monitoring outbox relay service execution frequency<br> <li> Implements startup grace period to avoid false negatives during <br>initialization<br> <li> Reports degraded/unhealthy status based on configurable time <br>thresholds<br> <li> Multipliers applied to polling interval for dynamic threshold <br>calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-c656d4a330241e59266455f6696396ee944a10105ea231c2369b029236554b29">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayWorker.cs</strong><dd><code>Background worker for periodic outbox processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxRelayWorker.cs

<ul><li>Background service that periodically triggers outbox message <br>publishing<br> <li> Uses PeriodicTimer for configurable polling intervals<br> <li> Records successful execution metrics and handles processing errors <br>gracefully<br> <li> Logs type-to-topic mappings and configuration details on startup</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-c5f670ed5fc1bbec84e2b27cd251e78af218504ff18882010b907fdd421098b9">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>KafkaProducerDiagnostics.cs</strong><dd><code>OpenTelemetry tracing for Kafka producer operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/KafkaProducerDiagnostics.cs

<ul><li>OpenTelemetry activity creation for Kafka producer operations<br> <li> Extracts and restores trace context from outbox message headers<br> <li> Sets production-essential semantic convention tags for messaging <br>operations<br> <li> Handles delivery callbacks to update activity status and tags</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-76b11bfc672514748bbeab532efe42c6ce8d58e8e315ab93acde36c1cc954cd2">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HostEnvironmentExtensions.cs</strong><dd><code>Host environment detection extension methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Extensions/HostEnvironmentExtensions.cs

<ul><li>Extension methods for checking host environment names<br> <li> Provides IsLocal(), IsTesting(), and IsInCluster() helpers<br> <li> Enables environment-specific configuration and behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-d076b6bb581cc06f599471c07d284c46db660f2a3c842b3c57f66a2a636c15fa">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxDbContext.cs</strong><dd><code>Entity Framework Core context for outbox messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/OutboxDbContext.cs

<ul><li>Entity Framework Core DbContext for outbox message persistence<br> <li> Configures OutboxMessage entity using OutboxMessageConfiguration<br> <li> Applies schema and table name from OutboxRelayOptions</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-48bda558967f6427f7cb9322b07b08f1ad7e7add19de9211f2dc9f6f4497f153">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayActivitySource.cs</strong><dd><code>OpenTelemetry ActivitySource initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxRelayActivitySource.cs

<ul><li>Static ActivitySource for OutboxRelay distributed tracing<br> <li> Initialized with app name and version from instrumentation metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-7c3b813c5110d18ae6de8a020448287064a6e03b77493b7af23432e881ac289d">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayInstrumentation.cs</strong><dd><code>Assembly instrumentation metadata extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/OutboxRelayInstrumentation.cs

<ul><li>Extracts assembly metadata for instrumentation<br> <li> Provides app name and version for OpenTelemetry and logging</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-5f6fdcd01851b261b8c87e0b76cd35e59116a5f5ddd76888e62b1c46d6970e19">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ObservabilityDependencyInjection.cs</strong><dd><code>OpenTelemetry and Serilog observability configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/ObservabilityDependencyInjection.cs

<ul><li>Configures Serilog logging with console and OpenTelemetry sinks<br> <li> Sets up OpenTelemetry tracing and metrics with OTLP exporter<br> <li> Configures resource detection for container and host environments<br> <li> Enables runtime and process instrumentation with exemplar filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-9351be3cb7b90cac07736bc94a744130fdcbdbf3e305afcd365945abb99a35df">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthChecksDependencyInjection.cs</strong><dd><code>Health checks and Prometheus metrics endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/HealthChecksDependencyInjection.cs

<ul><li>Registers health checks for database, Kafka, and outbox relay <br>execution<br> <li> Maps readiness and liveness endpoints with appropriate tag filtering<br> <li> Configures Prometheus exporter for health check metrics<br> <li> Supports configurable timeouts for each health check component</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-f890c35069327191e241d96559e8051c36f43fa2d340d37bcdceecec411c0835">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>KafkaProducerOptions.cs</strong><dd><code>Kafka producer configuration with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/KafkaProducerOptions.cs

<ul><li>Configuration class for Kafka producer settings inheriting from <br>ProducerConfig<br> <li> Validates required fields like ClientId, BootstrapServers, Acks, and <br>EnableIdempotence<br> <li> Exposes optional tuning parameters for compression, batching, and <br>retry behavior<br> <li> Includes shallow clone method for configuration copying</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-55b29799ea8975b257e5138f3dd37548f09bc7dccf73bbc1c23d08070d794ed6">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayHealthCheckOptions.cs</strong><dd><code>Health check configuration with threshold validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/HealthChecks/OutboxRelayHealthCheckOptions.cs

<ul><li>Configuration options for outbox relay health check thresholds<br> <li> Validates multipliers and minimum thresholds for degraded/unhealthy <br>states<br> <li> Includes startup grace period to allow service initialization<br> <li> Custom validation ensures logical consistency between threshold values</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-14a74d1757e92a3f49e8ba61da6c23d300fc732bab49fdcc9ce67cb0f2804e22">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayOptions.cs</strong><dd><code>Outbox relay configuration with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/Config/OutboxRelayOptions.cs

<ul><li>Configuration for outbox relay polling, batch size, and topic mappings<br> <li> Validates polling interval, batch size, and topic name constraints<br> <li> Supports type-specific Kafka topic routing with default fallback<br> <li> Configurable database schema and table names with SQL identifier <br>validation</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-e662ecf1267ec4b5cf6b8ec6011d90290be6ef11e906a8e074726d20c5e56d39">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayDependencyInjection.cs</strong><dd><code>Dependency injection for outbox relay services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/OutboxRelayDependencyInjection.cs

<ul><li>Registers OutboxRelayWorker and OutboxMessageRelay services<br> <li> Configures Kafka producer with log handler for Serilog integration<br> <li> Maps Confluent.Kafka log levels to .NET logging levels<br> <li> Validates configuration options on startup</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-2a3f8cdb03d0a979d1c2b0435efea2f76c653f81062d2b94e633ad221f678651">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PersistenceDependencyInjection.cs</strong><dd><code>Entity Framework Core database configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/PersistenceDependencyInjection.cs

<ul><li>Configures Entity Framework Core with SQL Server and connection <br>pooling<br> <li> Sets up retry policies with configurable max count and delay<br> <li> Registers pooled DbContextFactory for efficient database access<br> <li> Enables detailed errors for development environments</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-65c8c67568401a4545067b39bbaa001d6dcff2c0fc11075cb1bc7a480cc121b4">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxDiagnosticNames.cs</strong><dd><code>OpenTelemetry semantic convention constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Tracing/OutboxDiagnosticNames.cs

<ul><li>Constants for OpenTelemetry semantic convention tag names<br> <li> Defines messaging system, operation, and destination attributes<br> <li> Includes Kafka-specific tags for message key and offset<br> <li> Follows OTEL semantic conventions for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-7fdc67ec564c5d50edec4e70b6437ff9bb01eea4103355d8b7252ea6ac0ac9a6">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Program.cs</strong><dd><code>Application startup and service configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Program.cs

<ul><li>Application entry point configuring all services and middleware<br> <li> Initializes Serilog bootstrap logger for startup logging<br> <li> Registers observability, health checks, database, and outbox relay <br>services<br> <li> Maps health check endpoints and Prometheus exporter</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-27d5e2405c425a193f2ff7359b0cfe62c463e65f61e87910834803afec65f83e">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxRelayMetricConstants.cs</strong><dd><code>Metric constants and tag definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxRelayMetricConstants.cs

<ul><li>Constants for metric tag keys and processed count category values<br> <li> Defines message type and processed count dimensions<br> <li> Provides categorization for batch sizes (none, single, tiny, small, <br>etc.)</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-a8e54343fbda8c2d4be318e9dca3d88df549cfb9eba883ce34d6983bb9d0b618">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthChecksOptions.cs</strong><dd><code>Health check timeout configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/HealthChecksOptions.cs

<ul><li>Configuration for health check timeout values<br> <li> Validates timeout ranges for self, outbox relay, and Kafka checks<br> <li> Supports configurable timeouts for different health check components</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-cd28f22d04749465f6d6c25477366aea9979aa7fe2c824d3aea3d1d15b3bab37">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EfCoreOptions.cs</strong><dd><code>Entity Framework Core configuration options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/EfCoreOptions.cs

<ul><li>Configuration for Entity Framework Core settings<br> <li> Validates database context pool size and retry parameters<br> <li> Supports detailed error reporting for development</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-1c7f332a896ff403fd500ce3755061ed65ad86ba4811f5af6200348745b12d0d">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OutboxMetricsCollectorOptions.cs</strong><dd><code>Metrics collector interval configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Observability/Metrics/OutboxMetricsCollectorOptions.cs

<ul><li>Configuration for outbox metrics collection interval<br> <li> Validates reporting interval between 1 and 300 seconds</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-64eb9c6336ac8053e92f1d0fb488650bf6b3fd3d9a7b90c2e84e92772fef54f4">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InfrastructureConstants.cs</strong><dd><code>Infrastructure endpoint and tag constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/InfrastructureConstants.cs

<ul><li>Constants for health check endpoint paths and tags<br> <li> Defines readiness, liveness, database, and messaging tags<br> <li> Specifies Prometheus metrics endpoint path</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-7b5cdc77faca2909dd364f06cab756d9d8295be3e0a134afa573335230851a56">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConnectionStringsOptions.cs</strong><dd><code>Database connection string configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/ConnectionStringsOptions.cs

<ul><li>Configuration for database connection strings<br> <li> Validates required Outbox connection string</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-da9af17e8e66dfdf6aee076f4ebd1cff1667fd407b9c12c3e1981a1866a137be">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appsettings.json</strong><dd><code>Application configuration settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.json

<ul><li>Application configuration for Serilog, Kafka, database, and health <br>checks<br> <li> Defines outbox relay polling, batch size, and type-to-topic mappings<br> <li> Configures health check thresholds and metrics collection intervals<br> <li> Includes OTEL exporter endpoint and connection strings</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-c667490819668a39d08885f8166319c37947ecd620c4bdd18daba6f7d7fd9bd9">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>launchSettings.json</strong><dd><code>Development launch settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Properties/launchSettings.json

<ul><li>Launch profile for local development environment<br> <li> Sets ASPNETCORE_ENVIRONMENT to Local<br> <li> Configures HTTPS and HTTP application URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-8aea5b048088517e2b3e111fb188a1d21e5bacd3fed41a6844099d4b1a0f57e2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Multi-stage Docker build configuration for worker service</code></dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Dockerfile

<ul><li>Multi-stage Docker build with base, build, publish, and final stages<br> <li> Base stage uses .NET 10.0 aspnet runtime with chiseled image and <br>configures environment variables for performance (<code>DOTNET_gcServer=1</code>, <br><code>DOTNET_TieredPGO=1</code>)<br> <li> Build stage restores dependencies with locked mode and builds the <br>worker service with version parameters<br> <li> Publish stage creates optimized release build with <br><code>PublishReadyToRun=true</code> for faster startup<br> <li> Final stage copies published artifacts and sets entrypoint to run the <br>worker service DLL</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-0c25121647a5ef33af3d895dad7e5d03945fde8a926dfbb95d089e330afd3c79">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DotNetAtlas.OutboxRelay.WorkerService.csproj</strong><dd><code>Project file with dependencies and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/DotNetAtlas.OutboxRelay.WorkerService.csproj

<ul><li>Defines project as Web SDK with package references for logging, <br>database, health checks, and OpenTelemetry instrumentation<br> <li> Includes Serilog for structured logging with console and OpenTelemetry <br>sinks<br> <li> Adds Entity Framework Core with SQL Server provider and design tools<br> <li> Configures health checks for Kafka and Prometheus metrics with EF Core <br>support<br> <li> References core outbox and EF Core integration projects as <br>dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-5ae668f1775ec4a1ebafd4dc82567b24fa4d75bc6ed9f6105ccfcebfe9f24c71">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appsettings.Local.json</strong><dd><code>Local development configuration settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/appsettings.Local.json

<ul><li>Configures Serilog logging with Debug minimum level for local <br>development<br> <li> Sets Microsoft and Entity Framework Core logging to Information level <br>to reduce noise<br> <li> Enables Avro schema auto-registration for Kafka communication<br> <li> Sets OutboxRelay polling interval to 500ms for local testing</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-46cb06746108c6d615fdc71e1ce00ccbf25310915e8ceeeeac4b8d972584bed7">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>packages.lock.json</strong><dd><code>NuGet package dependencies lock file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/packages.lock.json

<ul><li>NuGet package lock file with all dependencies resolved<br> <li> Includes Confluent.Kafka, Entity Framework Core, OpenTelemetry, and <br>Serilog<br> <li> Specifies versions for SQL Server, health checks, and observability <br>packages</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-36dde92485bc14be2f9319665afc99ba7c00d93d5b8e5ad4081f06d9c044409d">+870/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packages.lock.json</strong><dd><code>NuGet package lock file for OutboxRelay worker service</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/OutboxRelay/packages.lock.json

<ul><li>Added NuGet package lock file for .NET 10.0 runtime<br> <li> Specifies locked versions of <code>Microsoft.DotNet.ILCompiler</code> and <br><code>Microsoft.NET.ILLink.Tasks</code> (10.0.0-rc.1.25451.107)<br> <li> Includes platform-specific dependencies for linux-x64 and win-x64 <br>runtime identifiers<br> <li> Ensures reproducible builds with pinned package versions and content <br>hashes</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-b30c793d4e39a1e19ad915a1cc23e59a3dc1db3503321a389bb9690ef4c77e8c">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packages.lock.json</strong><dd><code>NuGet package lock file for Common Config module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/DotNetAtlas.OutboxRelay.WorkerService/Common/Config/packages.lock.json

<ul><li>Added NuGet package lock file for .NET 10.0 runtime<br> <li> Specifies locked versions of <code>Microsoft.DotNet.ILCompiler</code> and <br><code>Microsoft.NET.ILLink.Tasks</code> (10.0.0-rc.1.25451.107)<br> <li> Includes platform-specific dependencies for linux-x64 and win-x64 <br>runtime identifiers<br> <li> Ensures reproducible builds with pinned package versions and content <br>hashes</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/53/files#diff-56dbf03c81e0772cb2085786dd45673d0057faa7ae9ab6dffadf23aaae705bf5">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new OutboxRelay Worker Service that reads outbox records from SQL Server and publishes to Kafka with health checks, metrics, tracing, and configurable options.
> 
> - **Worker Service**:
>   - Adds `platform/DotNetAtlas.OutboxRelay.WorkerService` with `OutboxRelayWorker`, `OutboxMessageRelay`, and `OutboxDbContext` for batching and publishing outbox messages to Kafka.
>   - DI setup in `OutboxRelayDependencyInjection` and app bootstrap in `Program.cs`.
> - **Configuration & Options (validated)**:
>   - `OutboxRelayOptions`, `KafkaProducerOptions`, `EfCoreOptions`, `ConnectionStringsOptions`, `HealthChecksOptions`, `OutboxMetricsCollectorOptions` with data annotations.
>   - App settings in `appsettings.json` and local overrides in `appsettings.Local.json`.
> - **Observability**:
>   - OpenTelemetry tracing/metrics via `ObservabilityDependencyInjection`; Kafka producer spans in `KafkaProducerDiagnostics` and activity source in `OutboxRelayActivitySource`.
>   - Custom metrics in `OutboxRelayMetrics` and background `OutboxMetricsCollector`.
>   - Serilog logging with optional OTLP sink.
> - **Health Checks**:
>   - Registers self, EF Core (`OutboxDbContext`), Kafka, and execution checks (`OutboxRelayHealthCheck`); maps `/api/healthz`, `/api/readiness`, Prometheus exporter.
> - **Persistence**:
>   - SQL Server via pooled `DbContextFactory`, retries, and detailed errors configured in `PersistenceDependencyInjection`.
> - **Docker**:
>   - Multi-stage `Dockerfile` for build/publish on .NET 10 runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a101b839454f682d340a7909ca204000f9de5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->