### PR TITLE
feat(monitoring): add OutboxRelay dashboard and health metrics

### DIFF
--- a/src/grafana/provisioning/dashboards/outbox-relay-dashboard.json
+++ b/src/grafana/provisioning/dashboards/outbox-relay-dashboard.json
@@ -1,0 +1,1144 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "OutboxRelay service metrics for monitoring message lag, queue size, and processing performance",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 9,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 30000
+              },
+              {
+                "color": "red",
+                "value": 120000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "outbox_head_lag_milliseconds",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Oldest message lag (head of queue)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "outbox_tail_lag_milliseconds",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Newest message lag (tail of queue)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Lag Analysis (Head vs Tail)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "outbox_size_messages",
+          "interval": "",
+          "legendFormat": "Outbox Queue Size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Queue Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Processing Throughput (msg/s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed Rate (msg/s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success Rate (%)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "max",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "rate(outbox_messages_published_total[1m])",
+          "interval": "",
+          "legendFormat": "Processing Throughput (msg/s)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "rate(outbox_messages_failed_total[1m])",
+          "interval": "",
+          "legendFormat": "Failed Rate (msg/s)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  (rate(outbox_messages_published_total[1m]) + rate(outbox_messages_failed_total[1m])) > 0\n) * (\n  (rate(outbox_messages_published_total[1m]) / (rate(outbox_messages_published_total[1m]) + rate(outbox_messages_failed_total[1m]))) * 100\n) or on() vector(100)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Success Rate (%)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Message Processing Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"single\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Single: 1)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"single\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Single: 1)",
+          "range": true,
+          "refId": "B2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"tiny\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Tiny: 2-5)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"tiny\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Tiny: 2-5)",
+          "range": true,
+          "refId": "C2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"small\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Small: 6-10)",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"small\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Small: 6-10)",
+          "range": true,
+          "refId": "D2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"medium\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Medium: 11-25)",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"medium\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Medium: 11-25)",
+          "range": true,
+          "refId": "E2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"large\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Large: 26-50)",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"large\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Large: 26-50)",
+          "range": true,
+          "refId": "F2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"xlarge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (XLarge: 51-100)",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"xlarge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (XLarge: 51-100)",
+          "range": true,
+          "refId": "G2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"xxlarge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (XXLarge: 101-250)",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"xxlarge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (XXLarge: 101-250)",
+          "range": true,
+          "refId": "H2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"huge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Huge: 251-500)",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"huge\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Huge: 251-500)",
+          "range": true,
+          "refId": "I2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"massive\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Massive: 501-1000)",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"massive\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Massive: 501-1000)",
+          "range": true,
+          "refId": "J2"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"gigantic\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "99th Percentile (Gigantic: 1000+)",
+          "range": true,
+          "refId": "K"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(outbox_processing_duration_seconds_bucket{processed_count=\"gigantic\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "50th Percentile (Gigantic: 1000+)",
+          "range": true,
+          "refId": "K2"
+        }
+      ],
+      "title": "Processing Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Health Check Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "UNHEALTHY"
+                },
+                "1": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "DEGRADED"
+                },
+                "2": {
+                  "color": "green",
+                  "index": 2,
+                  "text": "HEALTHY"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "healthcheck{job=\"outbox-relay-healthchecks\",healthcheck=\"OutboxRelay Execution\"}",
+          "legendFormat": "OutboxRelay Status",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "OutboxRelay Health Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 60
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "outbox_time_since_last_successful_execution_seconds",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Time Since Last Successful Execution",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "expr": "healthcheck_duration_seconds{job=\"outbox-relay-healthchecks\",healthcheck=\"OutboxRelay Execution\"} * 1000",
+          "legendFormat": "Health Check Duration",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Check Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 10,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 1,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "UNHEALTHY"
+                },
+                "1": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "DEGRADED"
+                },
+                "2": {
+                  "color": "green",
+                  "index": 2,
+                  "text": "HEALTHY"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 13,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "healthcheck{job=\"outbox-relay-healthchecks\"}",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{healthcheck}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Status History",
+      "type": "state-timeline"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "outbox",
+    "messaging",
+    "kafka"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Background OutboxRelay Dashboard",
+  "uid": "outbox-relay-dashboard",
+  "version": 46
+}

--- a/src/prometheus/prometheus-config.yaml
+++ b/src/prometheus/prometheus-config.yaml
@@ -22,6 +22,16 @@ scrape_configs:
           app: dotnetatlas-api
           kind: healthchecks
 
+  - job_name: 'outbox-relay-healthchecks'
+    scrape_interval: 10s
+    scrape_timeout: 9s
+    metrics_path: /api/health/prometheus
+    static_configs:
+      - targets: ['outbox-relay:8080']
+        labels:
+          app: outbox-relay
+          kind: healthchecks
+
 otlp:
   promote_resource_attributes:
     - service.instance.id


### PR DESCRIPTION
### **User description**
Add comprehensive Grafana dashboard for OutboxRelay service with
monitoring panels for queue lag, message processing rates, throughput
performance, and health status. Configure Prometheus to scrape
OutboxRelay health metrics every 10 seconds.

Dashboard includes:
- Queue lag analysis (head vs tail messages)
- Outbox queue size tracking
- Message processing rates with success/failure metrics
- Processing duration percentiles by batch size
- Health check status and execution timing


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive Grafana dashboard for OutboxRelay service monitoring

- Configure Prometheus to scrape OutboxRelay health metrics every 10 seconds

- Dashboard includes queue lag, queue size, processing rates, and duration analysis

- Add health check status panels with execution timing and history visualization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Prometheus["Prometheus Config"] -->|scrapes every 10s| OutboxRelay["OutboxRelay Service"]
  OutboxRelay -->|exposes metrics| Grafana["Grafana Dashboard"]
  Grafana -->|displays| QueueMetrics["Queue Lag & Size"]
  Grafana -->|displays| ProcessingMetrics["Processing Rates & Duration"]
  Grafana -->|displays| HealthMetrics["Health Status & Timing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outbox-relay-dashboard.json</strong><dd><code>Create comprehensive OutboxRelay monitoring dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/grafana/provisioning/dashboards/outbox-relay-dashboard.json

<ul><li>Create new Grafana dashboard with 8 visualization panels for <br>OutboxRelay monitoring<br> <li> Panel 1: Queue lag analysis comparing head vs tail message lag with <br>thresholds<br> <li> Panel 2: Outbox queue size tracking with color-coded thresholds<br> <li> Panel 3: Message processing rates showing throughput, failure rate, <br>and success percentage<br> <li> Panel 4: Processing duration percentiles (50th and 99th) across 8 <br>batch size categories<br> <li> Panel 5: Health check status indicator with HEALTHY/DEGRADED/UNHEALTHY <br>states<br> <li> Panel 6: Time since last execution metric with warning thresholds<br> <li> Panel 7: Health check execution duration in milliseconds<br> <li> Panel 8: Health status history timeline visualization</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/57/files#diff-83237337114328bd44a4fe75feef10eb41d5b3d1cdd66237f4ecc6fd17fe0f10">+1144/-0</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prometheus-config.yaml</strong><dd><code>Configure Prometheus scraping for OutboxRelay health metrics</code></dd></summary>
<hr>

src/prometheus/prometheus-config.yaml

<ul><li>Add new scrape job configuration for OutboxRelay health checks<br> <li> Configure 10-second scrape interval for OutboxRelay metrics collection<br> <li> Set metrics endpoint to <code>/api/health/prometheus</code> on OutboxRelay service<br> <li> Target OutboxRelay service at <code>outbox-relay:8080</code> with appropriate <br>labels</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/57/files#diff-23a76c1512d00eb91d86c236bd0e6b264d0deea2159cd434330d431a9f234cc3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a comprehensive Grafana dashboard for OutboxRelay and configures Prometheus to scrape its health metrics every 10s.
> 
> - **Grafana Dashboard** (`src/grafana/provisioning/dashboards/outbox-relay-dashboard.json`):
>   - Timeseries panels for `outbox_head_lag_milliseconds` vs `outbox_tail_lag_milliseconds` and `outbox_size_messages`.
>   - Message processing rates: `rate(outbox_messages_published_total[1m])`, `rate(outbox_messages_failed_total[1m])`, and success rate %.
>   - Processing duration percentiles (p50/p99) across batch sizes via `outbox_processing_duration_seconds_bucket`.
>   - Health panels: `healthcheck{job="outbox-relay-healthchecks"}` status, `outbox_time_since_last_successful_execution_seconds`, `healthcheck_duration_seconds` (ms), and state timeline.
> - **Prometheus** (`src/prometheus/prometheus-config.yaml`):
>   - Add `outbox-relay-healthchecks` job scraping `/api/health/prometheus` at `outbox-relay:8080` every 10s with labels (`app: outbox-relay`, `kind: healthchecks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f7086d65404be33d2f84fc05a925608d4b9f2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->