### PR TITLE
test(outbox): Add Integration Test for Feedback Outbox Message publishing

### DIFF
--- a/test/DotNetAtlas.IntegrationTests/Application/WeatherFeedback/FeedbackOutboxTests.cs
+++ b/test/DotNetAtlas.IntegrationTests/Application/WeatherFeedback/FeedbackOutboxTests.cs
@@ -1,0 +1,84 @@
+using DotNetAtlas.Application.WeatherFeedback.ChangeFeedback;
+using DotNetAtlas.Application.WeatherFeedback.SendFeedback;
+using DotNetAtlas.IntegrationTests.Common;
+using FluentResults.Extensions.FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DotNetAtlas.IntegrationTests.Application.WeatherFeedback;
+
+[Collection<ForecastTestCollection>]
+public class FeedbackOutboxTests : BaseIntegrationTest
+{
+    private readonly SendFeedbackCommandHandler _sendFeedbackCommandHandler;
+    private readonly ChangeFeedbackCommandHandler _changeFeedbackCommandHandler;
+
+    public FeedbackOutboxTests(IntegrationTestFixture app)
+        : base(app)
+    {
+        _sendFeedbackCommandHandler =
+            new SendFeedbackCommandHandler(
+                Scope.ServiceProvider.GetRequiredService<ILogger<SendFeedbackCommandHandler>>(),
+                WeatherDbContext);
+        _changeFeedbackCommandHandler =
+            new ChangeFeedbackCommandHandler(
+                Scope.ServiceProvider.GetRequiredService<ILogger<ChangeFeedbackCommandHandler>>(),
+                WeatherDbContext);
+    }
+
+    [Fact]
+    public async Task WhenFeedbackCreatedAndChanged_PublishesBothDomainEventsViaOutbox()
+    {
+        // Arrange
+        var userId = Guid.CreateVersion7();
+        var sendFeedbackCommand = new SendFeedbackCommand
+        {
+            Feedback = "Excellent weather forecast!",
+            Rating = 5,
+            UserId = userId
+        };
+
+        // Act - Create Feedback
+        var sendFeedbackResult = await _sendFeedbackCommandHandler.HandleAsync(
+            sendFeedbackCommand,
+            TestContext.Current.CancellationToken);
+        sendFeedbackResult.Should().BeSuccess();
+        var createdId = sendFeedbackResult.Value;
+
+        var createdFeedback = await WeatherDbContext.Feedbacks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == createdId, TestContext.Current.CancellationToken);
+        createdFeedback.Should().NotBeNull();
+
+        // Change the feedback
+        var changeFeedbackCommand = new ChangeFeedbackCommand
+        {
+            Id = createdId,
+            Feedback = "Updated weather forecast feedback!",
+            Rating = 4,
+            UserId = userId
+        };
+
+        var changeFeedbackResult = await _changeFeedbackCommandHandler.HandleAsync(
+            changeFeedbackCommand,
+            TestContext.Current.CancellationToken);
+        changeFeedbackResult.Should().BeSuccess();
+
+        var last2OutboxMessages = await WeatherDbContext.OutboxMessages
+            .AsNoTracking()
+            .OrderByDescending(om => om.Id)
+            .Take(2)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            last2OutboxMessages.Should().HaveCount(2);
+            last2OutboxMessages[1].KafkaKey.Should().Be(createdId.ToString());
+            last2OutboxMessages[1].Type.Should().Be("FeedbackCreatedEvent");
+            last2OutboxMessages[0].KafkaKey.Should().Be(createdId.ToString());
+            last2OutboxMessages[0].Type.Should().Be("FeedbackChangedEvent");
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
- Verifies that creating feedback generates FeedbackCreatedEvent in outbox
- Verifies that changing feedback generates FeedbackChangedEvent in outbox
- Ensures both domain events are properly persisted with correct Kafka keys and event types


___

### **PR Type**
Tests


___

### **Description**
- Adds integration test for feedback outbox message publishing

- Verifies FeedbackCreatedEvent generated when feedback created

- Verifies FeedbackChangedEvent generated when feedback changed

- Validates correct Kafka keys and event types persisted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SendFeedback["SendFeedback Command"] -- "creates" --> FeedbackCreatedEvent["FeedbackCreatedEvent"]
  ChangeFeedback["ChangeFeedback Command"] -- "creates" --> FeedbackChangedEvent["FeedbackChangedEvent"]
  FeedbackCreatedEvent -- "persists to" --> Outbox["Outbox Messages"]
  FeedbackChangedEvent -- "persists to" --> Outbox
  Outbox -- "validates" --> Test["Integration Test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedbackOutboxTests.cs</strong><dd><code>New integration test for feedback outbox events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/DotNetAtlas.IntegrationTests/Application/WeatherFeedback/FeedbackOutboxTests.cs

<ul><li>Creates new integration test class <code>FeedbackOutboxTests</code> extending <br><code>BaseIntegrationTest</code><br> <li> Initializes command handlers for <code>SendFeedbackCommandHandler</code> and <br><code>ChangeFeedbackCommandHandler</code> in constructor<br> <li> Implements single test method <br><code>WhenFeedbackCreatedAndChanged_PublishesBothDomainEventsViaOutbox</code> that <br>validates outbox message publishing<br> <li> Test verifies both <code>FeedbackCreatedEvent</code> and <code>FeedbackChangedEvent</code> are <br>persisted with correct Kafka keys and event types</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/59/files#diff-7acec213a7655e9af258ed424cbcab34243b9fe311492c3704821b5632f4d308">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an integration test that creates and updates feedback, asserting outbox publishes FeedbackCreatedEvent and FeedbackChangedEvent with correct Kafka keys.
> 
> - **Tests**:
>   - **`FeedbackOutboxTests`** (`test/DotNetAtlas.IntegrationTests/Application/WeatherFeedback/FeedbackOutboxTests.cs`)
>     - Uses `SendFeedbackCommandHandler` and `ChangeFeedbackCommandHandler` to create and update feedback.
>     - Verifies two outbox messages (latest first): `FeedbackChangedEvent` then `FeedbackCreatedEvent` with matching `KafkaKey` (created feedback ID).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea62a91e07b64ec6023f9b9081e93463b2cb7c8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->