### PR TITLE
feat(feedback): add OccurredOnUtc timestamp to Feedback domain events and update mappings

### DIFF
--- a/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackChangedDomainEvent.cs
+++ b/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackChangedDomainEvent.cs
@@ -37,4 +37,9 @@ public sealed record FeedbackChangedDomainEvent : IDomainEvent
     /// Current rating (1-5). If equal to OldRating, rating did not change.
     /// </summary>
     public required int NewRating { get; init; }
+
+    /// <summary>
+    /// UTC timestamp when event occurred.
+    /// </summary>
+    public required DateTimeOffset OccurredOnUtc { get; init; }
 }

--- a/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackCreatedDomainEvent.cs
+++ b/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackCreatedDomainEvent.cs
@@ -27,4 +27,9 @@ public sealed record FeedbackCreatedDomainEvent : IDomainEvent
     /// Initial rating (1-5).
     /// </summary>
     public required int Rating { get; init; }
+
+    /// <summary>
+    /// UTC timestamp when event occurred.
+    /// </summary>
+    public required DateTimeOffset OccurredOnUtc { get; init; }
 }

--- a/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Feedback.cs
+++ b/src/DotNetAtlas.Domain/Entities/Weather/Feedback/Feedback.cs
@@ -30,7 +30,8 @@ public sealed class Feedback : AggregateRoot<Guid>, IAuditableEntity
                 FeedbackId = Id,
                 UserId = CreatedByUser,
                 Rating = rating.Value,
-                Text = feedbackText.Value
+                Text = feedbackText.Value,
+                OccurredOnUtc = DateTimeOffset.UtcNow
             });
     }
 
@@ -54,7 +55,8 @@ public sealed class Feedback : AggregateRoot<Guid>, IAuditableEntity
                 NewRating = rating.Value,
                 OldRating = oldRating,
                 NewText = feedback.Value,
-                OldText = oldFeedbackText
+                OldText = oldFeedbackText,
+                OccurredOnUtc = DateTimeOffset.UtcNow
             });
     }
 

--- a/src/DotNetAtlas.Infrastructure/Messaging/Kafka/DomainToAvroMappings/FeedbackEventsToAvroMapper.cs
+++ b/src/DotNetAtlas.Infrastructure/Messaging/Kafka/DomainToAvroMappings/FeedbackEventsToAvroMapper.cs
@@ -9,14 +9,14 @@ public static partial class FeedbackEventsToAvroMapper
 {
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
     [MapValue(nameof(FeedbackCreatedEvent.EventId), Use = nameof(GenerateEventId))]
-    [MapValue(nameof(FeedbackCreatedEvent.OccurredOnUtc), Use = nameof(GenerateOccurredOnUtc))]
     public static partial FeedbackCreatedEvent ToFeedbackCreatedEvent(this FeedbackCreatedDomainEvent source);
 
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
     [MapValue(nameof(FeedbackChangedEvent.EventId), Use = nameof(GenerateEventId))]
-    [MapValue(nameof(FeedbackChangedEvent.OccurredOnUtc), Use = nameof(GenerateOccurredOnUtc))]
     public static partial FeedbackChangedEvent ToFeedbackChangedEvent(this FeedbackChangedDomainEvent source);
 
     private static Guid GenerateEventId() => Guid.CreateVersion7();
-    private static DateTime GenerateOccurredOnUtc() => DateTime.UtcNow;
+
+    [UserMapping]
+    private static DateTime DateTimeOffsetToDateTime(DateTimeOffset t) => t.UtcDateTime;
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `OccurredOnUtc` timestamp property to Feedback domain events

- Populate timestamp with `DateTimeOffset.UtcNow` when events are raised

- Update Avro mapper to convert `DateTimeOffset` to `DateTime`

- Remove automatic timestamp generation from mapper layer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feedback Domain Events"] -->|"Add OccurredOnUtc property"| B["FeedbackCreatedDomainEvent<br/>FeedbackChangedDomainEvent"]
  C["Feedback Entity"] -->|"Populate with DateTimeOffset.UtcNow"| B
  B -->|"Convert to DateTime"| D["Avro Mapper"]
  D -->|"Remove auto-generation"| E["Kafka Events"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedbackCreatedDomainEvent.cs</strong><dd><code>Add OccurredOnUtc timestamp property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackCreatedDomainEvent.cs

<ul><li>Add required <code>OccurredOnUtc</code> property of type <code>DateTimeOffset</code><br> <li> Include XML documentation for the new timestamp property</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/63/files#diff-18c3d863777f0d343f18e5dc28dd7e17fbcfb2d5c87d3a1aba8507f2982829c8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeedbackChangedDomainEvent.cs</strong><dd><code>Add OccurredOnUtc timestamp property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Domain/Entities/Weather/Feedback/Events/FeedbackChangedDomainEvent.cs

<ul><li>Add required <code>OccurredOnUtc</code> property of type <code>DateTimeOffset</code><br> <li> Include XML documentation for the new timestamp property</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/63/files#diff-3b5cc154e939c755f484518fb372a40e843319e36bbe1209b3ecd587c46c9bca">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Feedback.cs</strong><dd><code>Populate OccurredOnUtc in domain events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Domain/Entities/Weather/Feedback/Feedback.cs

<ul><li>Populate <code>OccurredOnUtc</code> with <code>DateTimeOffset.UtcNow</code> in <br><code>FeedbackCreatedDomainEvent</code><br> <li> Populate <code>OccurredOnUtc</code> with <code>DateTimeOffset.UtcNow</code> in <br><code>FeedbackChangedDomainEvent</code><br> <li> Ensure timestamp is captured at event creation time in domain layer</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/63/files#diff-bec115fcaadc6fe598ff45b6bf8161b8a1a8019e24498eeed719f286d1afafff">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeedbackEventsToAvroMapper.cs</strong><dd><code>Update mapper to use domain event timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DotNetAtlas.Infrastructure/Messaging/Kafka/DomainToAvroMappings/FeedbackEventsToAvroMapper.cs

<ul><li>Remove <code>[MapValue]</code> attributes that auto-generated <code>OccurredOnUtc</code> <br>timestamps<br> <li> Remove <code>GenerateOccurredOnUtc()</code> method that created automatic <br>timestamps<br> <li> Add <code>[UserMapping]</code> method to convert <code>DateTimeOffset</code> to <code>DateTime</code> for <br>Avro serialization<br> <li> Shift timestamp responsibility from mapper to domain layer</ul>


</details>


  </td>
  <td><a href="https://github.com/DavidCapcuch/DotNetAtlas/pull/63/files#diff-f6e43a33537035fbb14e661040cbc251539a6c828ba75b4a352226c25ee839c9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add OccurredOnUtc timestamp to Feedback domain events, populate in domain, and update Avro mapper to use provided timestamps with DateTimeOffset→DateTime conversion.
> 
> - **Domain Events**:
>   - Add required `OccurredOnUtc: DateTimeOffset` to `FeedbackCreatedDomainEvent` and `FeedbackChangedDomainEvent`.
> - **Aggregate (`Feedback`)**:
>   - Populate `OccurredOnUtc` with `DateTimeOffset.UtcNow` when raising `FeedbackCreatedDomainEvent` and `FeedbackChangedDomainEvent`.
> - **Infrastructure (Kafka Avro Mapping)**:
>   - Remove auto-generation of `OccurredOnUtc`; rely on domain-provided value.
>   - Keep `EventId` generation; add user mapping `DateTimeOffset -> DateTime` for serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d365237aa4fe18000050412669c12727c6cfc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->